### PR TITLE
Token split 2

### DIFF
--- a/appendix-hashtrees.tex
+++ b/appendix-hashtrees.tex
@@ -241,87 +241,6 @@ Indexed hash trees can be used to provide and verify both inclusion and exclusio
 \end{itemize}
 
 
-\section{Radix Sparse Merkle Sum Trees}\label{app:rsmst}
-
-A \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) is the radix sparse Merkle tree of Appendix~\ref{app:rsmt} with a positive amount at every leaf and an accumulated sum at every internal node. It is used for split allocation roots (Sec.~\ref{sec:token-splitting}). The tree deliberately reuses the RSMT key space, byte-order-preserving bit numbering, canonical path-compressed structure and inclusion-walk logic.
-
-\subsection{Tree Structure}
-
-Keys are 32-byte strings. For token splitting the key is the output token identifier $\mathsf{id}_j$, the leaf data is the 32-byte output commitment $d_j$, and the leaf amount is the positive asset allocation $v_j(\mathsf{aid})$.
-
-An RSMST leaf carries $(k,d,v)$ where $k,d\in\bytes{32}$ and $1\leq v<2^{256}$. An internal node carries an absolute bifurcation depth $\delta\in\{0,\ldots,255\}$ and two child pairs $(h_L,v_L)$ and $(h_R,v_R)$; its sum is $v_L+v_R$. Construction MUST use the same canonical path-compressed binary trie as RSMT, MUST reject duplicate keys and zero-valued leaves, and MUST reject any internal sum overflow. A split allocation tree is never empty.
-
-For a tree $\mathcal{S}$, $\Call{RSMSTRoot}{\mathcal{S}}$ returns the root hash and root sum. If $\mathcal{S}$ has one leaf, the root hash is that leaf hash and the root sum is that leaf amount. Otherwise the root is the hash and sum of the top internal node.
-
-\subsection{Hash Computation}
-
-Hash inputs use fixed binary encodings, not general-purpose CBOR tuples. Let $\Call{u256}{x}$ be the 32-byte big-endian encoding of $x$ and let $\Call{u8}{\delta}$ be the one-byte encoding of $\delta$. Define one-byte domain separators:
-\[
-\mathsf{RSMST\_LEAF}=\mathtt{0x10},\qquad
-\mathsf{RSMST\_NODE}=\mathtt{0x11}.
-\]
-
-\begin{algorithmic}
-	\Function{rsmst\_leaf\_hash}{$k,d,v$}
-		\State \Return $\mathsf{SHA\text{-}256}(\mathsf{RSMST\_LEAF}\|k\|d\|\Call{u256}{v})$
-	\EndFunction
-\end{algorithmic}
-
-\begin{algorithmic}
-	\Function{rsmst\_node\_hash}{$\delta,(h_L,v_L),(h_R,v_R)$}
-		\State $v \gets v_L+v_R$ using checked 256-bit addition; on overflow return $(\bot,0)$
-		\State $h \gets \mathsf{SHA\text{-}256}(\mathsf{RSMST\_NODE}\|\Call{u8}{\delta}\|h_L\|\Call{u256}{v_L}\|h_R\|\Call{u256}{v_R})$
-		\State \Return $(h,v)$
-	\EndFunction
-\end{algorithmic}
-
-\subsection{Explicit-Depth Inclusion Proof}\label{sec:rsmst-inclusion-proof}
-
-An RSMST inclusion proof is a leaf-to-root sequence of sibling entries:
-\[
-C^\mathsf{inc}=\langle(\delta_1,s_1,w_1),\ldots,(\delta_n,s_n,w_n)\rangle,
-\]
-where $0\leq n\leq256$, $\delta_i\in\{0,\ldots,255\}$ is the sibling's parent bifurcation depth, $s_i\in\hashtype$ is the sibling subtree hash, and $1\leq w_i<2^{256}$ is the sibling subtree sum. Depths MUST be strictly decreasing in proof order because the proof is ordered from the leaf toward the root. No bitmap is carried; the depth in each sibling entry fully identifies the branch step.
-
-\subsection{Function $\textsc{rsmst\_verify\_inclusion}$}\label{sec:rsmst-verify-inclusion}
-
-\textbf{Input}:
-\begin{enumerate}
-	\item $k \in \bytes{32}$ -- expected leaf key;
-	\item $d \in \bytes{32}$ -- expected leaf data;
-	\item $v \in \mathbb{N}$, $1\leq v<2^{256}$ -- expected leaf amount;
-	\item $C^\mathsf{inc}$ -- explicit-depth inclusion proof; and
-	\item $r \in \bytes{32}$ -- expected root hash.
-\end{enumerate}
-
-\textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
-
-\begin{algorithmic}
-	\Function{rsmst\_verify\_inclusion}{$k,d,v,C^\mathsf{inc},r$}
-		\If{$v=0$, $v\geq2^{256}$, $\len{C^\mathsf{inc}}>256$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
-		\State $h \gets \Call{rsmst\_leaf\_hash}{k,d,v}$
-		\State $v_\mathsf{sum} \gets v$
-		\State $\delta_\mathsf{prev}\gets256$
-		\ForAll{$(\delta,s,w)$ in $C^\mathsf{inc}$}
-			\If{$\delta\geq\delta_\mathsf{prev}$, $\delta\notin\{0,\ldots,255\}$, $w=0$, or $w\geq2^{256}$}
-				\State \Return $(\FALSE,0)$
-			\EndIf
-			\If{bit $\delta$ of $k$ is $0$}
-				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(h,v_\mathsf{sum}),(s,w)}$
-			\Else
-				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(s,w),(h,v_\mathsf{sum})}$
-			\EndIf
-			\If{$h'=\bot$} \State \Return $(\FALSE,0)$ \EndIf
-			\State $h\gets h'$
-			\State $v_\mathsf{sum}\gets v'$
-			\State $\delta_\mathsf{prev}\gets\delta$
-		\EndFor
-		\State \Return $((h=r),v_\mathsf{sum})$
-	\EndFunction
-\end{algorithmic}
-
-The verifier checks value conservation by comparing $v_\mathsf{root}$ to the authenticated source amount for the same asset. The root hash alone is not sufficient: sibling sums are verification-critical proof data because they are committed by every internal node hash.
-
 \section{Radix Sparse Merkle Trees}\label{app:rsmt}
 
 A \emph{Radix Sparse Merkle Tree}\index{Radix Sparse Merkle Tree} (RSMT) is a leaf-anchored, path-compressed binary Merkle tree over a 256-bit key space. It authenticates a finite map $k \mapsto v$, where every stored key appears as exactly one leaf and every internal node records the absolute bit position at which its descendant keys bifurcate. The implementation documented here uses byte-order-preserving LSB-in-byte bit numbering. Each leaf hash commits to the full 256-bit key, and each internal node hash commits to the explicit bifurcation depth. Consequently, splitting an edge above an unchanged subtree does not alter that subtree's hash: batch insertion rehashes only the changed search frontier and the newly created nodes. The tree supports inclusion certificates, non-inclusion certificates and consistency proofs.
@@ -784,3 +703,85 @@ When receiving a ZK-compressed consistency proof, the verifier must:
 	\item Verify the ZK proof, obtaining authentic public inputs $h'$, $h$
 	\item Confirm these values match the claimed Input Reco	rd
 \end{enumerate}
+
+
+\section{Radix Sparse Merkle Sum Trees}\label{app:rsmst}
+
+A \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) is the radix sparse Merkle tree of Appendix~\ref{app:rsmt} with a positive amount at every leaf and an accumulated sum at every internal node. It is used for split allocation roots (Sec.~\ref{sec:token-splitting}). The tree deliberately reuses the RSMT key space, byte-order-preserving bit numbering, canonical path-compressed structure and inclusion-walk logic.
+
+\subsection{Tree Structure}
+
+Keys are 32-byte strings. For token splitting the key is the output token identifier $\mathsf{id}_j$, the leaf data is the 32-byte output commitment $d_j$, and the leaf amount is the positive asset allocation $v_j(\mathsf{aid})$.
+
+An RSMST leaf carries $(k,d,v)$ where $k,d\in\bytes{32}$ and $1\leq v<2^{256}$. An internal node carries an absolute bifurcation depth $\delta\in\{0,\ldots,255\}$ and two child pairs $(h_L,v_L)$ and $(h_R,v_R)$; its sum is $v_L+v_R$. Construction MUST use the same canonical path-compressed binary trie as RSMT, MUST reject duplicate keys and zero-valued leaves, and MUST reject any internal sum overflow. A split allocation tree is never empty.
+
+For a tree $\mathcal{S}$, $\Call{RSMSTRoot}{\mathcal{S}}$ returns the root hash and root sum. If $\mathcal{S}$ has one leaf, the root hash is that leaf hash and the root sum is that leaf amount. Otherwise the root is the hash and sum of the top internal node.
+
+\subsection{Hash Computation}
+
+Hash inputs use fixed binary encodings, not general-purpose CBOR tuples. Let $\Call{u256}{x}$ be the 32-byte big-endian encoding of $x$ and let $\Call{u8}{\delta}$ be the one-byte encoding of $\delta$. Define one-byte domain separators:
+\[
+\mathsf{RSMST\_LEAF}=\mathtt{0x10},\qquad
+\mathsf{RSMST\_NODE}=\mathtt{0x11}.
+\]
+
+\begin{algorithmic}
+	\Function{rsmst\_leaf\_hash}{$k,d,v$}
+		\State \Return $\mathsf{SHA\text{-}256}(\mathsf{RSMST\_LEAF}\|k\|d\|\Call{u256}{v})$
+	\EndFunction
+\end{algorithmic}
+
+\begin{algorithmic}
+	\Function{rsmst\_node\_hash}{$\delta,(h_L,v_L),(h_R,v_R)$}
+		\State $v \gets v_L+v_R$ using checked 256-bit addition; on overflow return $(\bot,0)$
+		\State $h \gets \mathsf{SHA\text{-}256}(\mathsf{RSMST\_NODE}\|\Call{u8}{\delta}\|h_L\|\Call{u256}{v_L}\|h_R\|\Call{u256}{v_R})$
+		\State \Return $(h,v)$
+	\EndFunction
+\end{algorithmic}
+
+\subsection{Explicit-Depth Inclusion Proof}\label{sec:rsmst-inclusion-proof}
+
+An RSMST inclusion proof is a leaf-to-root sequence of sibling entries:
+\[
+C^\mathsf{inc}=\langle(\delta_1,s_1,w_1),\ldots,(\delta_n,s_n,w_n)\rangle,
+\]
+where $0\leq n\leq256$, $\delta_i\in\{0,\ldots,255\}$ is the sibling's parent bifurcation depth, $s_i\in\hashtype$ is the sibling subtree hash, and $1\leq w_i<2^{256}$ is the sibling subtree sum. Depths MUST be strictly decreasing in proof order because the proof is ordered from the leaf toward the root. No bitmap is carried; the depth in each sibling entry fully identifies the branch step.
+
+\subsection{Function $\textsc{rsmst\_verify\_inclusion}$}\label{sec:rsmst-verify-inclusion}
+
+\textbf{Input}:
+\begin{enumerate}
+	\item $k \in \bytes{32}$ -- expected leaf key;
+	\item $d \in \bytes{32}$ -- expected leaf data;
+	\item $v \in \mathbb{N}$, $1\leq v<2^{256}$ -- expected leaf amount;
+	\item $C^\mathsf{inc}$ -- explicit-depth inclusion proof; and
+	\item $r \in \bytes{32}$ -- expected root hash.
+\end{enumerate}
+
+\textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
+
+\begin{algorithmic}
+	\Function{rsmst\_verify\_inclusion}{$k,d,v,C^\mathsf{inc},r$}
+		\If{$v=0$, $v\geq2^{256}$, $\len{C^\mathsf{inc}}>256$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
+		\State $h \gets \Call{rsmst\_leaf\_hash}{k,d,v}$
+		\State $v_\mathsf{sum} \gets v$
+		\State $\delta_\mathsf{prev}\gets256$
+		\ForAll{$(\delta,s,w)$ in $C^\mathsf{inc}$}
+			\If{$\delta\geq\delta_\mathsf{prev}$, $\delta\notin\{0,\ldots,255\}$, $w=0$, or $w\geq2^{256}$}
+				\State \Return $(\FALSE,0)$
+			\EndIf
+			\If{bit $\delta$ of $k$ is $0$}
+				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(h,v_\mathsf{sum}),(s,w)}$
+			\Else
+				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(s,w),(h,v_\mathsf{sum})}$
+			\EndIf
+			\If{$h'=\bot$} \State \Return $(\FALSE,0)$ \EndIf
+			\State $h\gets h'$
+			\State $v_\mathsf{sum}\gets v'$
+			\State $\delta_\mathsf{prev}\gets\delta$
+		\EndFor
+		\State \Return $((h=r),v_\mathsf{sum})$
+	\EndFunction
+\end{algorithmic}
+
+The verifier checks value conservation by comparing $v_\mathsf{root}$ to the authenticated source amount for the same asset. The root hash alone is not sufficient: sibling sums are verification-critical proof data because they are committed by every internal node hash.

--- a/appendix-hashtrees.tex
+++ b/appendix-hashtrees.tex
@@ -241,146 +241,86 @@ Indexed hash trees can be used to provide and verify both inclusion and exclusio
 \end{itemize}
 
 
-\section{Sparse Merkle Sum Trees}\label{app:smst}
+\section{Radix Sparse Merkle Sum Trees}\label{app:rsmst}
 
-A \emph{Sparse Merkle Sum Tree}\index{Sparse Merkle Sum Tree} (SMST) extends Sparse Merkle Tree with value tracking. Each node carries both a hash and a non-negative integer value. Internal nodes sum their children's values, enabling cryptographic proofs that a leaf's value is part of a known total. This structure is used for value conservation proofs in token splitting (Sec.~\ref{sec:token-splitting}).
+A \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) is the radix sparse Merkle tree of Appendix~\ref{app:rsmt} with a positive amount at every leaf and an accumulated sum at every internal node. It is used for split allocation roots (Sec.~\ref{sec:token-splitting}). The tree deliberately reuses the RSMT key space, LSB-first bit order, canonical path-compressed structure and inclusion-walk logic.
 
-\subsection{Node Structure}
+\subsection{Tree Structure}
 
-Each node in an SMST carries a pair $(h, v)$, where $h \in \hashtype$ is the node hash and $v \in \mathbb{N}$ is the accumulated value.
+Keys are 32-byte strings. For token splitting the key is the output token identifier $\mathsf{id}_j$, the leaf data is the 32-byte output commitment $d_j$, and the leaf amount is the positive asset allocation $v_j(\mathsf{aid})$.
 
-\begin{itemize}
-	\item \textbf{Leaf node}: $(h, v)$ where:
-	\begin{itemize}
-		\item $p$ -- positive SMST path segment from this leaf to its parent
-		\item $d \in \bytes{\ast}$ -- leaf data
-		\item $v \in \mathbb{N}$ -- leaf value (e.g. asset amount)
-		\item $h = \Call{smst\_leaf\_hash}{p,d,v}$
-	\end{itemize}
-	\item \textbf{Branch node}: $(h, v)$ where:
-	\begin{itemize}
-		\item $p$ -- positive SMST path segment from this node to its parent
-		\item $(h_L, v_L)$ -- left child hash and value
-		\item $(h_R, v_R)$ -- right child hash and value
-		\item $(h,v) = \Call{smst\_branch\_hash}{p,(h_L,v_L),(h_R,v_R)}$
-		\item $v = v_L + v_R$
-	\end{itemize}
-	\item \textbf{Root node}: Uses the fixed path label $p = 1$ in hash computation:
-	\begin{itemize}
-		\item $(h,v) = \Call{smst\_branch\_hash}{1,(h_L,v_L),(h_R,v_R)}$
-	\end{itemize}
-\end{itemize}
+An RSMST leaf carries $(k,d,v)$ where $k,d\in\bytes{32}$ and $1\leq v<2^{256}$. An internal node carries an absolute bifurcation depth $\delta\in\{0,\ldots,255\}$ and two child pairs $(h_L,v_L)$ and $(h_R,v_R)$; its sum is $v_L+v_R$. Construction MUST use the same canonical path-compressed binary trie as RSMT, MUST reject duplicate keys and zero-valued leaves, and MUST reject any internal sum overflow. A split allocation tree is never empty.
 
-An empty child is represented by $(h, v) = (\bot, 0)$.
+For a tree $\mathcal{S}$, $\Call{RSMSTRoot}{\mathcal{S}}$ returns the root hash and root sum. If $\mathcal{S}$ has one leaf, the root hash is that leaf hash and the root sum is that leaf amount. Otherwise the root is the hash and sum of the top internal node.
 
-\subsubsection{Path Representation}
-SMST paths are non-empty bit strings represented as positive integers.  The bits of such an integer are read from least significant to most significant bit; this is the leaf-to-root order used by inclusion certificates.  The rightmost bit of the conventional binary representation is therefore the first path bit consumed when moving from a child to its parent, and it determines whether the current child is left ($0$) or right ($1$).  The root segment is the one-bit path $1$.
+\subsection{Hash Computation}
 
-For positive path integers $a$ and $b$, $a\|b$ denotes LSB-first path concatenation:
+Hash inputs use fixed binary encodings, not general-purpose CBOR tuples. Let $\Call{u256}{x}$ be the 32-byte big-endian encoding of $x$ and let $\Call{u8}{\delta}$ be the one-byte encoding of $\delta$. Define one-byte domain separators:
 \[
-a\|b = a + (b \ll \ell(a)),
+\mathsf{RSMST\_LEAF}=\mathtt{0x10},\qquad
+\mathsf{RSMST\_NODE}=\mathtt{0x11}.
 \]
-where $\ell(a)$ is the bit length of $a$.  This appends $b$ on the parent side of $a$.  On the wire and in hash inputs, every path integer is encoded as its minimal unsigned big-endian byte string; zero is not a valid path segment.
 
-For a 32-byte application key $k$, split allocation trees use the canonical SMST key path $\Call{smst\_key\_path}{k}$ whose minimal unsigned big-endian representation is $\mathtt{0x01}\|k$.  Under the LSB-first reading above, this path consists of the 256 bits of $k$ from least significant to most significant, followed by the root sentinel bit $1$.
-
-\subsubsection{Canonical Construction and Hashing}
-An SMST used for token splitting is the canonical path-compressed binary trie over distinct canonical key paths.  Construction MUST reject duplicate key paths and zero-valued leaves.  Unary internal nodes are elided into maximal path segments, and each branch has both left and right child positions, with an absent child represented by $(\bot,0)$.  $\Call{SMSTRoot}{}$ returns the root hash and accumulated root value of this canonical tree, and $\Call{CompactPath}{}$ returns the unique leaf-to-root sequence of path segments and sibling pairs from that tree.
-
-SMST hash inputs are deterministic CBOR tuples with explicit domain separators.  Define $\mathsf{SMST\_LEAF}$ as the ASCII byte string \texttt{UNICITY\_SMST\_LEAF} and $\mathsf{SMST\_BRANCH}$ as the ASCII byte string \texttt{UNICITY\_SMST\_BRANCH}.  Path segments and sums are encoded as minimal unsigned big-endian byte strings, hashes are raw 32-byte strings, and $\bot$ is encoded as CBOR \texttt{null}.
-
-\subsection{Function $\textsc{smst\_leaf\_hash}$}\label{sec:smst-leaf-hash}
-
-Computes the hash of an SMST leaf node.
-
-\textbf{Input}:
-\begin{enumerate}
-	\item $p$ -- positive SMST path segment from this leaf to its parent
-	\item $d \in \hashtype$ -- leaf data
-	\item $v \in \mathbb{N}$ -- leaf value
-\end{enumerate}
-
-\textbf{Output}: $h \in \hashtype$ -- hash of the leaf node
-
-\textbf{Computation}:
 \begin{algorithmic}
-	\Function{smst\_leaf\_hash}{$p, d, v$}
-		\State \Return $\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SMST\_LEAF},p,d,v))$
+	\Function{rsmst\_leaf\_hash}{$k,d,v$}
+		\State \Return $\mathsf{SHA\text{-}256}(\mathsf{RSMST\_LEAF}\|k\|d\|\Call{u256}{v})$
 	\EndFunction
 \end{algorithmic}
 
-\subsection{Function $\textsc{smst\_branch\_hash}$}\label{sec:smst-branch-hash}
-
-Computes the hash and accumulated value of an SMST branch node.
-
-\textbf{Input}:
-\begin{enumerate}
-	\item $p$ -- positive SMST path segment from this node to its parent
-	\item $(h_L, v_L) \in (\hashtype \cup \{\bot\}) \times \mathbb{N}$ -- left child
-	\item $(h_R, v_R) \in (\hashtype \cup \{\bot\}) \times \mathbb{N}$ -- right child
-\end{enumerate}
-
-\textbf{Output}: $(h, v) \in \hashtype \times \mathbb{N}$ -- hash and value of the branch node
-
-\textbf{Computation}:
 \begin{algorithmic}
-	\Function{smst\_branch\_hash}{$p, (h_L, v_L), (h_R, v_R)$}
-		\State $h \gets \mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SMST\_BRANCH},p,h_L,v_L,h_R,v_R))$
-		\State $v \gets v_L + v_R$
-		\State \Return $(h, v)$
+	\Function{rsmst\_node\_hash}{$\delta,(h_L,v_L),(h_R,v_R)$}
+		\State $v \gets v_L+v_R$ using checked 256-bit addition; on overflow return $(\bot,0)$
+		\State $h \gets \mathsf{SHA\text{-}256}(\mathsf{RSMST\_NODE}\|\Call{u8}{\delta}\|h_L\|\Call{u256}{v_L}\|h_R\|\Call{u256}{v_R})$
+		\State \Return $(h,v)$
 	\EndFunction
 \end{algorithmic}
 
-\subsection{Inclusion Certificate}\label{sec:smst-inclusion-cert}
+\subsection{Explicit-Depth Inclusion Proof}\label{sec:rsmst-inclusion-proof}
 
-An \emph{Inclusion Certificate} for an SMST leaf with key $k$ is a sequence of triples:
+An RSMST inclusion proof is a leaf-to-root sequence of sibling entries:
 \[
-C^\mathsf{inc} = \langle (p_1, d_1, v_1), (p_2, d_2, v_2), \ldots, (p_n, d_n, v_n) \rangle
+C^\mathsf{inc}=\langle(\delta_1,s_1,w_1),\ldots,(\delta_n,s_n,w_n)\rangle,
 \]
-where:
-\begin{itemize}
-	\item $(p_1, d_1, v_1)$ -- the leaf's path segment, data, and value
-	\item $(p_i, d_i, v_i)$ for $i > 1$ -- path segment $p_i$ to parent, sibling hash $d_i$, and sibling value $v_i$
-\end{itemize}
+where $0\leq n\leq256$, $\delta_i\in\{0,\ldots,255\}$ is the sibling's parent bifurcation depth, $s_i\in\hashtype$ is the sibling subtree hash, and $1\leq w_i<2^{256}$ is the sibling subtree sum. Depths MUST be strictly decreasing in proof order because the proof is ordered from the leaf toward the root. No bitmap is carried; the depth in each sibling entry fully identifies the branch step.
 
-\subsection{Function $\textsc{smst\_verify\_inclusion}$}\label{sec:smst-verify-inclusion}
-
-Verifies an SMST inclusion certificate by reconstructing the root hash and total value.
+\subsection{Function $\textsc{rsmst\_verify\_inclusion}$}\label{sec:rsmst-verify-inclusion}
 
 \textbf{Input}:
 \begin{enumerate}
-	\item $k$ -- expected complete SMST key path
-	\item $v_\mathsf{leaf} \in \mathbb{N}$ -- expected leaf value
-	\item $C^\mathsf{inc} = \langle (p_1, d_1, v_1), \ldots, (p_n, d_n, v_n) \rangle$ -- inclusion certificate
-	\item $h_{\mathsf{root}} \in \hashtype$ -- expected root hash
+	\item $k \in \bytes{32}$ -- expected leaf key;
+	\item $d \in \bytes{32}$ -- expected leaf data;
+	\item $v \in \mathbb{N}$, $1\leq v<2^{256}$ -- expected leaf amount;
+	\item $C^\mathsf{inc}$ -- explicit-depth inclusion proof; and
+	\item $r \in \bytes{32}$ -- expected root hash.
 \end{enumerate}
 
-\textbf{Output}: \TRUE or \FALSE
+\textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
 
-\textbf{Computation}:
 \begin{algorithmic}
-	\Function{smst\_verify\_inclusion}{$k, v_\mathsf{leaf}, C^\mathsf{inc}, h_{\mathsf{root}}$}
-		\If {$v_1 \neq v_\mathsf{leaf}$}
-			\State \Return \FALSE \Comment{Leaf value mismatch}
-		\EndIf
-		\State $h \gets \Call{smst\_leaf\_hash}{p_1,d_1,v_1}$
-		\State $v_\mathsf{sum} \gets v_1$
-		\State $q \gets p_1$ \Comment{Reconstructed path}
-		\For {$i \gets 2$ to $n$}
-			\State $b \gets$ rightmost bit of $p_{i-1}$
-			\If {$b = 0$}
-				\State $(h,\_) \gets \Call{smst\_branch\_hash}{p_i,(h,v_\mathsf{sum}),(d_i,v_i)}$ \Comment{Current is left child}
-			\Else
-				\State $(h,\_) \gets \Call{smst\_branch\_hash}{p_i,(d_i,v_i),(h,v_\mathsf{sum})}$ \Comment{Current is right child}
+	\Function{rsmst\_verify\_inclusion}{$k,d,v,C^\mathsf{inc},r$}
+		\If{$v=0$, $v\geq2^{256}$, $\len{C^\mathsf{inc}}>256$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
+		\State $h \gets \Call{rsmst\_leaf\_hash}{k,d,v}$
+		\State $v_\mathsf{sum} \gets v$
+		\State $\delta_\mathsf{prev}\gets256$
+		\ForAll{$(\delta,s,w)$ in $C^\mathsf{inc}$}
+			\If{$\delta\geq\delta_\mathsf{prev}$, $\delta\notin\{0,\ldots,255\}$, $w=0$, or $w\geq2^{256}$}
+				\State \Return $(\FALSE,0)$
 			\EndIf
-			\State $v_\mathsf{sum} \gets v_\mathsf{sum} + v_i$
-			\State $q \gets q \| p_i$ \Comment{Extend reconstructed path}
+			\If{bit $\delta$ of $k$ is $0$}
+				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(h,v_\mathsf{sum}),(s,w)}$
+			\Else
+				\State $(h',v')\gets\Call{rsmst\_node\_hash}{\delta,(s,w),(h,v_\mathsf{sum})}$
+			\EndIf
+			\If{$h'=\bot$} \State \Return $(\FALSE,0)$ \EndIf
+			\State $h\gets h'$
+			\State $v_\mathsf{sum}\gets v'$
+			\State $\delta_\mathsf{prev}\gets\delta$
 		\EndFor
-		\State \Return $(h = h_{\mathsf{root}}) \land (q = k)$
+		\State \Return $((h=r),v_\mathsf{sum})$
 	\EndFunction
 \end{algorithmic}
 
-In addition to verifying the root hash, the accumulated sum $v_\mathsf{sum}$ at the root equals the total value in the tree, enabling value conservation checks: the verifier confirms both that the leaf value matches the claimed allocation and that the root sum matches the original token's total value for the given asset.
+The verifier checks value conservation by comparing $v_\mathsf{root}$ to the authenticated source amount for the same asset. The root hash alone is not sufficient: sibling sums are verification-critical proof data because they are committed by every internal node hash.
 
 \section{Radix Sparse Merkle Trees}\label{app:rsmt}
 

--- a/appendix-hashtrees.tex
+++ b/appendix-hashtrees.tex
@@ -252,27 +252,42 @@ Each node in an SMST carries a pair $(h, v)$, where $h \in \hashtype$ is the nod
 \begin{itemize}
 	\item \textbf{Leaf node}: $(h, v)$ where:
 	\begin{itemize}
-		\item $p \in \bitstr$ -- path label from this leaf to its parent
+		\item $p$ -- positive SMST path segment from this leaf to its parent
 		\item $d \in \bytes{\ast}$ -- leaf data
 		\item $v \in \mathbb{N}$ -- leaf value (e.g. asset amount)
-		\item $h = H(p, d, v)$
+		\item $h = \Call{smst\_leaf\_hash}{p,d,v}$
 	\end{itemize}
 	\item \textbf{Branch node}: $(h, v)$ where:
 	\begin{itemize}
-		\item $p \in \bitstr$ -- path label from this node to its parent
+		\item $p$ -- positive SMST path segment from this node to its parent
 		\item $(h_L, v_L)$ -- left child hash and value
 		\item $(h_R, v_R)$ -- right child hash and value
-		\item $h = H(p, h_L, v_L, h_R, v_R)$
+		\item $(h,v) = \Call{smst\_branch\_hash}{p,(h_L,v_L),(h_R,v_R)}$
 		\item $v = v_L + v_R$
 	\end{itemize}
 	\item \textbf{Root node}: Uses the fixed path label $p = 1$ in hash computation:
 	\begin{itemize}
-		\item $h = H(1, h_L, v_L, h_R, v_R)$
-		\item $v = v_L + v_R$
+		\item $(h,v) = \Call{smst\_branch\_hash}{1,(h_L,v_L),(h_R,v_R)}$
 	\end{itemize}
 \end{itemize}
 
 An empty child is represented by $(h, v) = (\bot, 0)$.
+
+\subsubsection{Path Representation}
+SMST paths are non-empty bit strings represented as positive integers.  The bits of such an integer are read from least significant to most significant bit; this is the leaf-to-root order used by inclusion certificates.  The rightmost bit of the conventional binary representation is therefore the first path bit consumed when moving from a child to its parent, and it determines whether the current child is left ($0$) or right ($1$).  The root segment is the one-bit path $1$.
+
+For positive path integers $a$ and $b$, $a\|b$ denotes LSB-first path concatenation:
+\[
+a\|b = a + (b \ll \ell(a)),
+\]
+where $\ell(a)$ is the bit length of $a$.  This appends $b$ on the parent side of $a$.  On the wire and in hash inputs, every path integer is encoded as its minimal unsigned big-endian byte string; zero is not a valid path segment.
+
+For a 32-byte application key $k$, split allocation trees use the canonical SMST key path $\Call{smst\_key\_path}{k}$ whose minimal unsigned big-endian representation is $\mathtt{0x01}\|k$.  Under the LSB-first reading above, this path consists of the 256 bits of $k$ from least significant to most significant, followed by the root sentinel bit $1$.
+
+\subsubsection{Canonical Construction and Hashing}
+An SMST used for token splitting is the canonical path-compressed binary trie over distinct canonical key paths.  Construction MUST reject duplicate key paths and zero-valued leaves.  Unary internal nodes are elided into maximal path segments, and each branch has both left and right child positions, with an absent child represented by $(\bot,0)$.  $\Call{SMSTRoot}{}$ returns the root hash and accumulated root value of this canonical tree, and $\Call{CompactPath}{}$ returns the unique leaf-to-root sequence of path segments and sibling pairs from that tree.
+
+SMST hash inputs are deterministic CBOR tuples with explicit domain separators.  Define $\mathsf{SMST\_LEAF}$ as the ASCII byte string \texttt{UNICITY\_SMST\_LEAF} and $\mathsf{SMST\_BRANCH}$ as the ASCII byte string \texttt{UNICITY\_SMST\_BRANCH}.  Path segments and sums are encoded as minimal unsigned big-endian byte strings, hashes are raw 32-byte strings, and $\bot$ is encoded as CBOR \texttt{null}.
 
 \subsection{Function $\textsc{smst\_leaf\_hash}$}\label{sec:smst-leaf-hash}
 
@@ -280,7 +295,7 @@ Computes the hash of an SMST leaf node.
 
 \textbf{Input}:
 \begin{enumerate}
-	\item $p \in \bitstr$ -- path segment from this leaf to its parent
+	\item $p$ -- positive SMST path segment from this leaf to its parent
 	\item $d \in \hashtype$ -- leaf data
 	\item $v \in \mathbb{N}$ -- leaf value
 \end{enumerate}
@@ -290,7 +305,7 @@ Computes the hash of an SMST leaf node.
 \textbf{Computation}:
 \begin{algorithmic}
 	\Function{smst\_leaf\_hash}{$p, d, v$}
-		\State \Return $H(p, d, v)$
+		\State \Return $\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SMST\_LEAF},p,d,v))$
 	\EndFunction
 \end{algorithmic}
 
@@ -300,7 +315,7 @@ Computes the hash and accumulated value of an SMST branch node.
 
 \textbf{Input}:
 \begin{enumerate}
-	\item $p \in \bitstr$ -- path segment from this node to its parent
+	\item $p$ -- positive SMST path segment from this node to its parent
 	\item $(h_L, v_L) \in (\hashtype \cup \{\bot\}) \times \mathbb{N}$ -- left child
 	\item $(h_R, v_R) \in (\hashtype \cup \{\bot\}) \times \mathbb{N}$ -- right child
 \end{enumerate}
@@ -310,7 +325,7 @@ Computes the hash and accumulated value of an SMST branch node.
 \textbf{Computation}:
 \begin{algorithmic}
 	\Function{smst\_branch\_hash}{$p, (h_L, v_L), (h_R, v_R)$}
-		\State $h \gets H(p, h_L, v_L, h_R, v_R)$
+		\State $h \gets \mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SMST\_BRANCH},p,h_L,v_L,h_R,v_R))$
 		\State $v \gets v_L + v_R$
 		\State \Return $(h, v)$
 	\EndFunction
@@ -334,7 +349,7 @@ Verifies an SMST inclusion certificate by reconstructing the root hash and total
 
 \textbf{Input}:
 \begin{enumerate}
-	\item $k \in \hashtype$ -- key
+	\item $k$ -- expected complete SMST key path
 	\item $v_\mathsf{leaf} \in \mathbb{N}$ -- expected leaf value
 	\item $C^\mathsf{inc} = \langle (p_1, d_1, v_1), \ldots, (p_n, d_n, v_n) \rangle$ -- inclusion certificate
 	\item $h_{\mathsf{root}} \in \hashtype$ -- expected root hash
@@ -348,15 +363,15 @@ Verifies an SMST inclusion certificate by reconstructing the root hash and total
 		\If {$v_1 \neq v_\mathsf{leaf}$}
 			\State \Return \FALSE \Comment{Leaf value mismatch}
 		\EndIf
-		\State $h \gets H(p_1, d_1, v_1)$ \Comment{Hash leaf node}
+		\State $h \gets \Call{smst\_leaf\_hash}{p_1,d_1,v_1}$
 		\State $v_\mathsf{sum} \gets v_1$
 		\State $q \gets p_1$ \Comment{Reconstructed path}
 		\For {$i \gets 2$ to $n$}
 			\State $b \gets$ rightmost bit of $p_{i-1}$
 			\If {$b = 0$}
-				\State $h \gets H(p_i, h, v_\mathsf{sum}, d_i, v_i)$ \Comment{Current is left child}
+				\State $(h,\_) \gets \Call{smst\_branch\_hash}{p_i,(h,v_\mathsf{sum}),(d_i,v_i)}$ \Comment{Current is left child}
 			\Else
-				\State $h \gets H(p_i, d_i, v_i, h, v_\mathsf{sum})$ \Comment{Current is right child}
+				\State $(h,\_) \gets \Call{smst\_branch\_hash}{p_i,(d_i,v_i),(h,v_\mathsf{sum})}$ \Comment{Current is right child}
 			\EndIf
 			\State $v_\mathsf{sum} \gets v_\mathsf{sum} + v_i$
 			\State $q \gets q \| p_i$ \Comment{Extend reconstructed path}

--- a/appendix-hashtrees.tex
+++ b/appendix-hashtrees.tex
@@ -243,7 +243,7 @@ Indexed hash trees can be used to provide and verify both inclusion and exclusio
 
 \section{Radix Sparse Merkle Sum Trees}\label{app:rsmst}
 
-A \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) is the radix sparse Merkle tree of Appendix~\ref{app:rsmt} with a positive amount at every leaf and an accumulated sum at every internal node. It is used for split allocation roots (Sec.~\ref{sec:token-splitting}). The tree deliberately reuses the RSMT key space, LSB-first bit order, canonical path-compressed structure and inclusion-walk logic.
+A \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) is the radix sparse Merkle tree of Appendix~\ref{app:rsmt} with a positive amount at every leaf and an accumulated sum at every internal node. It is used for split allocation roots (Sec.~\ref{sec:token-splitting}). The tree deliberately reuses the RSMT key space, byte-order-preserving bit numbering, canonical path-compressed structure and inclusion-walk logic.
 
 \subsection{Tree Structure}
 
@@ -324,11 +324,11 @@ The verifier checks value conservation by comparing $v_\mathsf{root}$ to the aut
 
 \section{Radix Sparse Merkle Trees}\label{app:rsmt}
 
-A \emph{Radix Sparse Merkle Tree}\index{Radix Sparse Merkle Tree} (RSMT) is a leaf-anchored, path-compressed binary Merkle tree over a 256-bit key space. It authenticates a finite map $k \mapsto v$, where every stored key appears as exactly one leaf and every internal node records the absolute bit position at which its descendant keys bifurcate. The implementation documented here uses LSB-first bit order.\footnote{Reference Python implementation: \href{https://github.com/unicitynetwork/unicity-yellowpaper-tex/blob/main/ndrsmt3o.py}{\texttt{ndrsmt3o.py}}.} Each leaf hash commits to the full 256-bit key, and each internal node hash commits to the explicit bifurcation depth. Consequently, splitting an edge above an unchanged subtree does not alter that subtree's hash: batch insertion rehashes only the changed search frontier and the newly created nodes. The tree supports inclusion certificates, non-inclusion certificates and consistency proofs.
+A \emph{Radix Sparse Merkle Tree}\index{Radix Sparse Merkle Tree} (RSMT) is a leaf-anchored, path-compressed binary Merkle tree over a 256-bit key space. It authenticates a finite map $k \mapsto v$, where every stored key appears as exactly one leaf and every internal node records the absolute bit position at which its descendant keys bifurcate. The implementation documented here uses byte-order-preserving LSB-in-byte bit numbering. Each leaf hash commits to the full 256-bit key, and each internal node hash commits to the explicit bifurcation depth. Consequently, splitting an edge above an unchanged subtree does not alter that subtree's hash: batch insertion rehashes only the changed search frontier and the newly created nodes. The tree supports inclusion certificates, non-inclusion certificates and consistency proofs.
 
 \subsection{Tree Structure}
 
-Keys are elements of $\bytes{32}$ (256 bits), addressed in LSB-first order\footnote{See Appendix~\ref{app:ordering} for bit-string conventions.}. Bit position $i$ means the $i$-th least significant bit.
+Keys are elements of $\bytes{32}$ (256 bits). Write $k=k_0\|k_1\|\cdots\|k_{31}$ in wire byte order. Bit position $i$ addresses bit $i\bmod 8$ of byte $k_{\lfloor i/8\rfloor}$, where bit $0$ of a byte is its least significant bit. Thus depth $0$ reads the low bit of $k_0$, depth $7$ reads the high bit of $k_0$, depth $8$ reads the low bit of $k_1$, and depth $255$ reads the high bit of $k_{31}$. Tree traversal MUST NOT reinterpret the key as a single big-endian integer for bit addressing.
 
 \subsubsection{Node Format}
 
@@ -471,7 +471,7 @@ For an unordered batch of size $m$, the initial sort costs $O(m \log m)$. The re
 
 \subsection{Shard Split}\label{sec:rsmt-shard-split}
 
-When a shard $\sigma$ is split into two sub-shards $\sigma \| 0$ and $\sigma \| 1$ (Sec.~\ref{sec:sharding}), the RSMT maintained by the parent shard must be partitioned accordingly: each successor keeps only those leaves whose keys route to it under the sharding function $f_{\mathcal{SH}}$. In the LSB-first convention of Section~\ref{sec:rsmt-sort-order}, a key $k$ belongs to $\sigma \| b$ if bit $|\sigma|$ of $k$ equals $b$.
+When a shard $\sigma$ is split into two sub-shards $\sigma \| 0$ and $\sigma \| 1$ (Sec.~\ref{sec:sharding}), the RSMT maintained by the parent shard must be partitioned accordingly: each successor keeps only those leaves whose keys route to it under the sharding function $f_{\mathcal{SH}}$. In the bit-numbering convention of Section~\ref{app:rsmt}, a key $k$ belongs to $\sigma \| b$ if bit $|\sigma|$ of $k$ equals $b$.
 
 \subsubsection{Function $\textsc{rsmt\_shard\_split}$}\label{sec:rsmt-shard-split-fn}
 
@@ -536,8 +536,8 @@ An \emph{Inclusion Certificate}\index{Inclusion Certificate!RSMT} $C^\mathsf{inc
 
 An inclusion certificate is a pair $C^\mathsf{inc} = (\mathit{bitmap}, \mathit{siblings})$ where:
 \begin{itemize}
-	\item $\mathit{bitmap} \in \bytes{32}$ -- a 256-bit vector. Bit $d$ is set if and only if a sibling hash is required at depth $d$ on the path from the leaf to the root.
-	\item $\mathit{siblings} = \langle s_1, \ldots, s_n \rangle \in \hashtype^n$ where $n = \mathsf{bitcount}(\mathit{bitmap})$ -- sibling hashes ordered leaf-to-root (ascending depth).
+	\item $\mathit{bitmap} \in \bytes{32}$ -- a 256-bit vector. Bit $d$ is stored as bit $d\bmod 8$ of byte $\lfloor d/8\rfloor$ and is set if and only if a sibling hash is required at depth $d$ on the path from the leaf to the root.
+	\item $\mathit{siblings} = \langle s_1, \ldots, s_n \rangle \in \hashtype^n$ where $n = \mathsf{bitcount}(\mathit{bitmap})$ -- sibling hashes ordered root-to-leaf (ascending depth).
 \end{itemize}
 
 \noindent\textbf{Wire format}: $\mathit{bitmap}[32] \,\|\, s_1[32] \,\|\, \ldots \,\|\, s_n[32]$, for a total of $32 + 32n$ bytes.
@@ -593,7 +593,7 @@ A non-inclusion certificate is a tuple $C^\mathsf{exc} = (k_\ell, h_\ell, \mathi
 	\item $k_\ell \in \bytes{32}$ -- key of the neighbouring leaf
 	\item $h_\ell \in \hashtype$ -- hash of the neighbouring leaf ($= \Call{rsmt\_leaf\_hash}{k_\ell, v_\ell}$)
 	\item $\mathit{bitmap} \in \bytes{32}$ -- branching-depth bitmap (same semantics as inclusion certificate, Section~\ref{sec:rsmt-inclusion-cert})
-	\item $\mathit{siblings} = \langle s_1, \ldots, s_n \rangle \in \hashtype^n$ where $n = \mathsf{bitcount}(\mathit{bitmap})$ -- sibling hashes, leaf-to-root
+	\item $\mathit{siblings} = \langle s_1, \ldots, s_n \rangle \in \hashtype^n$ where $n = \mathsf{bitcount}(\mathit{bitmap})$ -- sibling hashes, root-to-leaf
 \end{itemize}
 
 \noindent\textbf{Wire format}: $k_\ell[32] \,\|\, h_\ell[32] \,\|\, \mathit{bitmap}[32] \,\|\, s_1[32] \,\|\, \ldots \,\|\, s_n[32]$, for a total of $96 + 32n$ bytes.
@@ -658,11 +658,11 @@ The current implementation proves preservation of committed pre-state subtrees a
 
 \subsubsection{Sort Order}\label{sec:rsmt-sort-order}
 
-The batch and proof use \emph{LSB-first traversal order}. The sort key of a 256-bit key $k$ is obtained by reversing the byte order of $k$ and then independently reversing the bits within each byte. This places the least significant bit of the key first in lexicographic order, matching the tree's branching order.
+The batch and proof use the tree traversal order defined in Section~\ref{app:rsmt}. The sort key of a 256-bit key $k=k_0\|k_1\|\cdots\|k_{31}$ is obtained by independently reversing the bits within each byte while preserving byte order. This places bit $0$ of $k_0$ first in lexicographic order, then bit $1$ of $k_0$, and so on through bit $7$ of $k_{31}$, matching the tree's branching order.
 
 \subsubsection{Proof Format}
 
-The proof $\pi$ is a flat stream of opcodes emitted from a post-order, LSB-first traversal of the tree:
+The proof $\pi$ is a flat stream of opcodes emitted from a post-order traversal of the tree in the order defined above:
 
 \begin{center}
 \begin{tabular}{clcl}

--- a/appendix-token.tex
+++ b/appendix-token.tex
@@ -273,25 +273,229 @@ All standard predicates that verify digital signatures ($\predi_\mathsf{sig}$, $
 
 \section{Split Proof Encoding}\label{app:split-proof-encoding}
 
-\subsection{Split Reason}
+This section specifies version~2 of the split mint reason described in Sec.~\ref{sec:token-splitting}.
 
-A split reason is encoded as a CBOR array with two elements:
+\subsection{Canonical Assets and Limits}
 
-\begin{longtable}{clp{8cm}}
+The token-type-specific function $\Call{Assets}{\mathsf{ty},\auxd'}$ returns a sequence
+\[
+\langle(\mathsf{aid}_1,v_1),\ldots,(\mathsf{aid}_m,v_m)\rangle
+\]
+strictly ordered by the raw bytes of $\mathsf{aid}_i$ using unsigned lexicographic comparison, with a shorter byte string ordered first when it is a prefix of another. Split version~2 requires:
+\begin{itemize}
+	\item $1 \leq m \leq 256$;
+	\item $1 \leq \len{\mathsf{aid}_i} \leq 128$ bytes;
+	\item $1 \leq v_i < 2^{256}$; and
+	\item no repeated asset identifier.
+\end{itemize}
+Amounts and SMST sums are encoded as minimal unsigned big-endian byte strings of at most 32 bytes. Zero is encoded by the empty byte string. An accepted non-empty integer encoding MUST NOT begin with \texttt{0x00}.
+
+All structures below use deterministic CBOR and must be consumed completely. Decoders MUST reject indefinite-length items, non-minimal heads or integers, wrong tags, unknown versions, wrong field counts or types, trailing bytes, duplicate or unordered assets, invalid lengths, arithmetic overflow, and exhausted cumulative byte, item, nesting, proof-step or embedded-token budgets.
+
+\subsection{Output Commitment}\label{app:split-output-commitment}
+
+The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Define $\mathsf{SPLIT\_OUTPUT\_V2}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT\_V2}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
+\[
+D_{\mathsf{mint},j}
+=(\alpha,\predi'_j,\mathsf{salt}_j,\mathsf{ty}_j,
+  \mathsf{reason}_j,\auxd'_j),
+\]
+derive
+\[
+\begin{split}
+\mathsf{id}_j &:= H(\mathsf{salt}_j,\alpha),\\
+d_j &:= \mathsf{SHA\text{-}256}\bigl(\mathsf{CBOR}(
+  \mathsf{SPLIT\_OUTPUT\_V2},
+  \mathsf{id}_\mathsf{src},
+  \alpha,
+  \encpred(\predi'_j),
+  \mathsf{salt}_j,
+  \mathsf{id}_j,
+  \mathsf{ty}_j,
+  \auxd'_j
+)\bigr).
+\end{split}
+\]
+Every term is encoded as a CBOR byte string except $\alpha$, which is an unsigned integer. In particular, $\auxd'_j$ is the exact auxiliary-payload byte string stored in the mint transaction, not a decoded or normalized object. The mint reason is deliberately excluded to avoid a circular commitment.
+
+\subsection{Split Manifest}\label{app:split-manifest}
+
+The final transfer of the source token stores a split manifest in its auxiliary-data byte string. The byte string contains CBOR semantic tag \texttt{39046} applied to the following two-element array:
+
+\begin{longtable}{clp{9cm}}
 \textbf{Index} & \textbf{Type} & \textbf{Description} \\
 \hline
-0 & CBOR structure & The burned source token (complete token encoding) \\
-1 & CBOR array & Array of split reason proofs (one per asset type) \\
+0 & unsigned integer & Split-manifest version; MUST equal $2$. \\
+1 & CBOR array & Ordered SMST root hashes $\langle r_1,\ldots,r_m\rangle$; each $r_i$ is the raw 32-byte SHA-256 digest. \\
 \end{longtable}
 
-\subsection{Split Reason Proof}
+The roots are positionally aligned with $\Call{Assets}{\mathsf{ty}_\mathsf{src},\auxd'_\mathsf{src}}$ in canonical asset order. The array length MUST equal the source asset count. Asset identifiers and source amounts are not repeated in the manifest.
 
-A split reason proof is encoded as a CBOR array with three elements:
+The source identifier is omitted. The certified transfer carrying the manifest is already part of the source token, and every allocation leaf is independently bound to that source identifier by $d_j$.
 
-\begin{longtable}{clp{8cm}}
+Let $b_\mathcal{M}$ be the complete canonical tagged CBOR encoding of the manifest. The certified burn transfer MUST contain $b_\mathcal{M}$ as its exact auxiliary-data value and MUST have burn reason set to its hash:
+\[
+\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M})).
+\]
+
+\subsection{Compact SMST Inclusion Proof}\label{app:compact-smst-proof}
+
+The SMST construction and hashing rules are defined in Appendix~\ref{app:smst}. For a leaf $(k,d,v)$, the ordinary certificate begins with $(p_1,d,v)$ and includes an expected root. In a split mint reason, $k=\mathsf{id}_j$, $d=d_j$, $v=v_j(\mathsf{aid})$, and the expected root comes from the manifest. These values are therefore omitted.
+
+A compact SMST inclusion proof is a two-element CBOR array:
+
+\begin{longtable}{clp{9cm}}
 \textbf{Index} & \textbf{Type} & \textbf{Description} \\
 \hline
-0 & byte string & Asset identifier $\mathsf{aid}$ \\
-1 & CBOR structure & Aggregation tree path (Sparse Merkle Tree path to the aggregation root) \\
-2 & CBOR structure & Asset sum tree path (Sparse Merkle Sum Tree path proving value allocation) \\
+0 & byte string & Leaf path segment $p_1$, encoded as a minimal unsigned big-endian integer. \\
+1 & CBOR array & One or more sibling steps, ordered leaf-to-root. \\
 \end{longtable}
+
+Each sibling step is a three-element CBOR array:
+
+\begin{longtable}{clp{9cm}}
+\textbf{Index} & \textbf{Type} & \textbf{Description} \\
+\hline
+0 & byte string & Path segment $p_i$ for this parent, encoded as a minimal unsigned big-endian integer. \\
+1 & byte string or \texttt{null} & Sibling subtree hash $s_i$; a hash is the raw 32-byte SHA-256 digest. \\
+2 & byte string & Sibling subtree sum $w_i$, minimally encoded. \\
+\end{longtable}
+
+Zero is encoded by the empty byte string and every positive path segment MUST NOT begin with \texttt{0x00}. Each path segment is positive and at most 33 bytes. A proof contains a leaf and between one and 256 sibling steps; its final parent segment MUST be $p_n=1$, the fixed SMST root label. The pair $(s_i,w_i)$ is canonical: $s_i=\bot$ if and only if $w_i=0$. No root hash, asset identifier, output identifier, leaf data or leaf amount occurs in the encoded proof.
+
+For a 32-byte key $k$, define $\Call{smst\_key\_path}{k}$ as the positive integer whose minimal big-endian representation is $\mathtt{0x01}\|k$. This sentinel preserves leading zero bits. Path concatenation below is the SMST path operation as specified in Appendix~\ref{app:smst}.
+
+\subsubsection{Function $\textsc{smst\_verify\_compact}$}\label{sec:smst-verify-compact}
+
+\textbf{Input}:
+\begin{enumerate}
+	\item $k \in \bytes{32}$ -- expected output token identifier;
+	\item $d \in \bytes{32}$ -- expected output commitment;
+	\item $v \in \mathbb{N}$, $1\leq v<2^{256}$ -- expected output amount;
+	\item $\bar C=(p_1,\langle(p_2,s_2,w_2),\ldots,(p_n,s_n,w_n)\rangle)$ -- compact proof; and
+	\item $r \in \bytes{32}$ -- expected raw root digest from the manifest.
+\end{enumerate}
+
+\textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
+
+\begin{algorithmic}
+	\Function{smst\_verify\_dcompact}{$k,d,v,\bar C,r$}
+		\If{$v=0$, $v\geq2^{256}$, $n<2$, $n>257$, $p_n\ne1$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
+		\State $h \gets \Call{smst\_leaf\_hash}{p_1,d,v}$
+		\State $v_\mathsf{sum} \gets v$
+		\State $q \gets p_1$
+		\State $p \gets p_1$
+		\For{$i \gets 2$ to $n$}
+			\If{$s_i=\bot$ and $w_i\ne0$, or $s_i\ne\bot$ and $w_i=0$}
+				\State \Return $(\FALSE,0)$
+			\EndIf
+			\State $v' \gets v_\mathsf{sum}+w_i$ using checked 256-bit addition; on overflow return $(\FALSE,0)$
+			\If{the rightmost bit of $p$ is $0$}
+				\State $(h',v'') \gets \Call{smst\_branch\_hash}{p_i,(h,v_\mathsf{sum}),(s_i,w_i)}$
+			\Else
+				\State $(h',v'') \gets \Call{smst\_branch\_hash}{p_i,(s_i,w_i),(h,v_\mathsf{sum})}$
+			\EndIf
+			\If{$v''\ne v'$} \State \Return $(\FALSE,0)$ \EndIf
+			\State $h \gets h'$
+			\State $v_\mathsf{sum} \gets v'$
+			\State $q \gets q\|p_i$
+			\State $p \gets p_i$
+		\EndFor
+		\State \Return $((h=r)\land(q=\Call{smst\_key\_path}{k}),v_\mathsf{sum})$
+	\EndFunction
+\end{algorithmic}
+
+An implementation MUST NOT accept a hash match without also checking the reconstructed key path. It MUST reject an overflowing intermediate sum before invoking a big-integer implementation that could silently accept values outside the 256-bit amount domain.
+
+\subsection{Split Mint Reason}\label{app:split-mint-reason}
+
+The mint-reason byte string of a split output contains CBOR semantic tag \texttt{39044} applied to this three-element array:
+
+\begin{longtable}{clp{9cm}}
+\textbf{Index} & \textbf{Type} & \textbf{Description} \\
+\hline
+0 & unsigned integer & Split mint-reason version; MUST equal $2$. \\
+1 & CBOR structure & Complete burned source token $\mathcal{L}_\mathsf{burn}$, including its certified manifest-bearing burn transfer. \\
+2 & CBOR array & Compact SMST proofs, one per output asset in canonical output-asset order. \\
+\end{longtable}
+
+The proof array contains no asset identifiers. Its length and positional interpretation are determined exclusively by $\Call{Assets}{\mathsf{ty}_j,\auxd'_j}$.
+
+\subsection{Split Construction Algorithm}\label{app:split-construction}
+
+\begin{algorithm}[!htbp]
+	\caption{Split Construction (Version 2)}\label{alg:split-construction-v2}
+	\begin{algorithmic}[0]
+		\Function{ConstructSplit}{$\mathcal{L},\langle D_{\mathsf{out},1},\ldots,D_{\mathsf{out},k}\rangle,\mathcal{T}$}
+			\State ensure($\Call{VerifyToken}{\mathcal{L},\mathcal{T}}=1$)
+			\State $D_\mathsf{src}\gets\mathcal{L}.T_0.D_\mathsf{mint}$
+			\State $\mathcal{A}\gets\Call{Assets}{D_\mathsf{src}.\mathsf{ty},D_\mathsf{src}.\auxd'}$
+			\State ensure($\mathcal{A}$ is non-empty and canonical)
+			\For{$j\gets1$ to $k$}
+				\State ensure($D_{\mathsf{out},j}.\alpha=\mathcal{T}.\alpha$)
+				\State $\mathsf{id}_j\gets H(D_{\mathsf{out},j}.\mathsf{salt},D_{\mathsf{out},j}.\alpha)$
+				\State ensure($\mathsf{id}_j$ is distinct among the outputs)
+				\State $\mathcal{A}_j\gets\Call{Assets}{D_{\mathsf{out},j}.\mathsf{ty},D_{\mathsf{out},j}.\auxd'}$
+				\State ensure($\mathcal{A}_j$ is non-empty, canonical, and contains no identifier absent from $\mathcal{A}$)
+				\State $d_j\gets\Call{split\_output\_commitment}{\mathcal{L}.\mathsf{id},D_{\mathsf{out},j}}$
+			\EndFor
+			\ForAll{$(\mathsf{aid}_i,v_i)\in\mathcal{A}$ in canonical order}
+				\State $\mathcal{S}_i\gets$ empty SMST
+				\For{$j\gets1$ to $k$}
+					\If{$(\mathsf{aid}_i,v_{i,j})\in\mathcal{A}_j$}
+						\State insert $(\mathsf{id}_j,d_j,v_{i,j})$ into $\mathcal{S}_i$
+					\EndIf
+				\EndFor
+				\State $(r_i,v'_i)\gets\Call{SMSTRoot}{\mathcal{S}_i}$
+				\State ensure($v'_i=v_i$)
+			\EndFor
+			\State $b_\mathcal{M}\gets\Call{EncodeSplitManifest}{2,\langle r_1,\ldots,r_m\rangle}$
+			\State construct burn transfer with auxiliary data $b_\mathcal{M}$ and recipient $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$
+			\For{$j\gets1$ to $k$}
+				\State $P_j\gets\langle\Call{CompactPath}{\mathcal{S}_i,\mathsf{id}_j}\mid(\mathsf{aid}_i,\_)\in\mathcal{A}_j\rangle$
+			\EndFor
+			\State durably persist $b_\mathcal{M}$, the burn transfer, and every $(D_{\mathsf{out},j},P_j)$
+			\State certify the burn and obtain $\mathcal{L}_\mathsf{burn}$
+			\For{$j\gets1$ to $k$}
+				\State $\mathsf{reason}_j\gets\Call{EncodeSplitReason}{2,\mathcal{L}_\mathsf{burn},P_j}$
+			\EndFor
+			\State \Return the burn transfer and output mint data with reasons $\mathsf{reason}_j$
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}
+
+The caller MUST persist all output mint fields and proofs before submitting the burn request. Reconstructing the same split after a failure requires byte-identical output fields, manifest and burn transfer.
+
+\subsection{Split Mint-Reason Verification Algorithm}\label{app:split-verification-algorithm}
+
+The following algorithm runs as the token-type-specific mint-reason check after normal verification of the output's certified mint transaction. Recursive calls share the same trust base, verifier registry, issuance policy and cumulative resource budget.
+
+\begin{algorithm}[!htbp]
+	\caption{Split Mint-Reason Verification (Version 2)}\label{alg:split-verify-v2}
+	\begin{algorithmic}[0]
+		\Function{VerifySplitReason}{$D_{\mathsf{mint},j},\mathcal{T},\mathsf{context}$}
+			\State $(2,\mathcal{L}_\mathsf{burn},P_j)\gets\Call{DecodeSplitReason}{D_{\mathsf{mint},j}.\mathsf{reason}}$
+			\State ensure($\Call{VerifyToken}{\mathcal{L}_\mathsf{burn},\mathcal{T},\mathsf{context}}=1$)
+			\State ensure($\mathcal{L}_\mathsf{burn}.\alpha=D_{\mathsf{mint},j}.\alpha=\mathcal{T}.\alpha$)
+			\State $T_\mathsf{burn}\gets$ final certified transfer of $\mathcal{L}_\mathsf{burn}$
+			\State $b_\mathcal{M}\gets T_\mathsf{burn}.\auxd'$
+			\State $(2,\langle r_1,\ldots,r_m\rangle)\gets\Call{DecodeSplitManifest}{b_\mathcal{M}}$
+			\State ensure($T_\mathsf{burn}.\predi'=\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$)
+			\State $D_\mathsf{src}\gets\mathcal{L}_\mathsf{burn}.T_0.D_\mathsf{mint}$
+			\State $\mathcal{A}\gets\Call{Assets}{D_\mathsf{src}.\mathsf{ty},D_\mathsf{src}.\auxd'}$
+			\State ensure($\len{\mathcal{A}}=m$ and $\mathcal{A}$ is canonical)
+			\State $\mathcal{A}_j\gets\Call{Assets}{D_{\mathsf{mint},j}.\mathsf{ty},D_{\mathsf{mint},j}.\auxd'}$
+			\State ensure($\mathcal{A}_j$ is non-empty and canonical and $\len{P_j}=\len{\mathcal{A}_j}$)
+			\State $\mathsf{id}_j\gets H(D_{\mathsf{mint},j}.\mathsf{salt},D_{\mathsf{mint},j}.\alpha)$
+			\State $d_j\gets\Call{split\_output\_commitment}{\mathcal{L}_\mathsf{burn}.\mathsf{id},D_{\mathsf{mint},j}}$
+			\For{$\ell\gets1$ to $\len{\mathcal{A}_j}$}
+				\State $(\mathsf{aid},v)\gets\mathcal{A}_j[\ell]$
+				\State $i\gets$ the unique index with $\mathcal{A}[i].\mathsf{aid}=\mathsf{aid}$; ensure it exists
+				\State $(b,v_\mathsf{root})\gets\Call{smst\_verify\_compact}{\mathsf{id}_j,d_j,v,P_j[\ell],r_i}$
+				\State ensure($b=\TRUE$)
+				\State ensure($v_\mathsf{root}=\mathcal{A}[i].v$)
+			\EndFor
+			\State \Return $1$
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}

--- a/appendix-token.tex
+++ b/appendix-token.tex
@@ -294,7 +294,7 @@ All structures below use deterministic CBOR and must be consumed completely. Dec
 
 \subsection{Output Commitment}\label{app:split-output-commitment}
 
-The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Define $\mathsf{SPLIT\_OUTPUT}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
+The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Split verification additionally requires the output token type to equal the source token type byte-for-byte; including $\mathsf{ty}_j$ in this commitment prevents replay of a prepared proof under any other mint transaction. Define $\mathsf{SPLIT\_OUTPUT}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
 \[
 D_{\mathsf{mint},j}
 =(\alpha,\predi'_j,\mathsf{salt}_j,\mathsf{ty}_j,
@@ -359,9 +359,9 @@ Each sibling step is a three-element CBOR array:
 2 & byte string & Sibling subtree sum $w_i$, minimally encoded. \\
 \end{longtable}
 
-Zero is encoded by the empty byte string and every positive path segment MUST NOT begin with \texttt{0x00}. Each path segment is positive and at most 33 bytes. A proof contains a leaf and between one and 256 sibling steps; its final parent segment MUST be $p_n=1$, the fixed SMST root label. The pair $(s_i,w_i)$ is canonical: $s_i=\bot$ if and only if $w_i=0$. No root hash, asset identifier, output identifier, leaf data or leaf amount occurs in the encoded proof.
+Zero is encoded by the empty byte string and every positive path segment MUST NOT begin with \texttt{0x00}. Each path segment is positive and at most 33 bytes. A proof contains a leaf and between one and 256 sibling steps; its final parent segment MUST be $p_n=1$, the fixed SMST root label. The decoded path segments are interpreted using the LSB-first SMST path representation and concatenation operation defined in Appendix~\ref{app:smst}; decoders MUST reject zero segments, non-minimal encodings, paths whose reconstructed length exceeds the split key-path length, or any reconstructed path other than the expected key path. The pair $(s_i,w_i)$ is canonical: $s_i=\bot$ if and only if $w_i=0$. No root hash, asset identifier, output identifier, leaf data or leaf amount occurs in the encoded proof.
 
-For a 32-byte key $k$, define $\Call{smst\_key\_path}{k}$ as the positive integer whose minimal big-endian representation is $\mathtt{0x01}\|k$. This sentinel preserves leading zero bits. Path concatenation below is the SMST path operation as specified in Appendix~\ref{app:smst}.
+For a 32-byte key $k$, define $\Call{smst\_key\_path}{k}$ as the positive integer whose minimal big-endian representation is $\mathtt{0x01}\|k$. Under the SMST LSB-first path representation, this is the 256 key bits followed by the root sentinel bit; the sentinel preserves leading zero bits of $k$ and fixes the split key path length to 257 bits.
 
 \subsubsection{Function $\textsc{smst\_verify\_compact}$}\label{sec:smst-verify-compact}
 
@@ -377,7 +377,7 @@ For a 32-byte key $k$, define $\Call{smst\_key\_path}{k}$ as the positive intege
 \textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
 
 \begin{algorithmic}
-	\Function{smst\_verify\_dcompact}{$k,d,v,\bar C,r$}
+	\Function{smst\_verify\_compact}{$k,d,v,\bar C,r$}
 		\If{$v=0$, $v\geq2^{256}$, $n<2$, $n>257$, $p_n\ne1$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
 		\State $h \gets \Call{smst\_leaf\_hash}{p_1,d,v}$
 		\State $v_\mathsf{sum} \gets v$
@@ -430,6 +430,7 @@ The proof array contains no asset identifiers. Its length and positional interpr
 			\State ensure($\mathcal{A}$ is non-empty and canonical)
 			\For{$j\gets1$ to $k$}
 				\State ensure($D_{\mathsf{out},j}.\alpha=\mathcal{T}.\alpha$)
+				\State ensure($D_{\mathsf{out},j}.\mathsf{ty}=D_\mathsf{src}.\mathsf{ty}$)
 				\State $\mathsf{id}_j\gets H(D_{\mathsf{out},j}.\mathsf{salt},D_{\mathsf{out},j}.\alpha)$
 				\State ensure($\mathsf{id}_j$ is distinct among the outputs)
 				\State $\mathcal{A}_j\gets\Call{Assets}{D_{\mathsf{out},j}.\mathsf{ty},D_{\mathsf{out},j}.\auxd'}$
@@ -479,6 +480,7 @@ The following algorithm runs as the token-type-specific mint-reason check after 
 			\State $\langle r_1,\ldots,r_m\rangle\gets\Call{DecodeSplitManifest}{b_\mathcal{M}}$
 			\State ensure($T_\mathsf{burn}.\predi'=\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$)
 			\State $D_\mathsf{src}\gets\mathcal{L}_\mathsf{burn}.T_0.D_\mathsf{mint}$
+			\State ensure($D_{\mathsf{mint},j}.\mathsf{ty}=D_\mathsf{src}.\mathsf{ty}$)
 			\State $\mathcal{A}\gets\Call{Assets}{D_\mathsf{src}.\mathsf{ty},D_\mathsf{src}.\auxd'}$
 			\State ensure($\len{\mathcal{A}}=m$ and $\mathcal{A}$ is canonical)
 			\State $\mathcal{A}_j\gets\Call{Assets}{D_{\mathsf{mint},j}.\mathsf{ty},D_{\mathsf{mint},j}.\auxd'}$

--- a/appendix-token.tex
+++ b/appendix-token.tex
@@ -288,7 +288,7 @@ strictly ordered by the raw bytes of $\mathsf{aid}_i$ using unsigned lexicograph
 	\item $1 \leq v_i < 2^{256}$; and
 	\item no repeated asset identifier.
 \end{itemize}
-Amounts and SMST sums are encoded as minimal unsigned big-endian byte strings of at most 32 bytes. Zero is encoded by the empty byte string. An accepted non-empty integer encoding MUST NOT begin with \texttt{0x00}.
+Amounts and RSMST sums are encoded as minimal unsigned big-endian byte strings of at most 32 bytes. Zero is encoded by the empty byte string where a surrounding structure permits zero; split allocation leaves and sibling sums are strictly positive. An accepted non-empty integer encoding MUST NOT begin with \texttt{0x00}.
 
 All structures below use deterministic CBOR and must be consumed completely. Decoders MUST reject indefinite-length items, non-minimal heads or integers, wrong or unknown tags, wrong field counts or types, trailing bytes, duplicate or unordered assets, invalid lengths, arithmetic overflow, and exhausted cumulative byte, item, nesting, proof-step or embedded-token budgets.
 
@@ -320,7 +320,7 @@ Every term is encoded as a CBOR byte string except $\alpha$, which is an unsigne
 
 \subsection{Split Manifest}\label{app:split-manifest}
 
-The final transfer of the source token stores a split manifest in its auxiliary-data byte string. The byte string contains CBOR semantic tag \texttt{39046} applied directly to an array of SMST root hashes:
+The final transfer of the source token stores a split manifest in its auxiliary-data byte string. The byte string contains CBOR semantic tag \texttt{39046} applied directly to an array of RSMST root hashes:
 
 \[
 \langle r_1,\ldots,r_m\rangle.
@@ -336,74 +336,38 @@ Let $b_\mathcal{M}$ be the complete canonical tagged CBOR encoding of the manife
 \predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M})).
 \]
 
-\subsection{Compact SMST Inclusion Proof}\label{app:compact-smst-proof}
+\subsection{Split Allocation Inclusion Proof}\label{app:split-allocation-proof}
 
-The SMST construction and hashing rules are defined in Appendix~\ref{app:smst}. For a leaf $(k,d,v)$, the ordinary certificate begins with $(p_1,d,v)$ and includes an expected root. In a split mint reason, $k=\mathsf{id}_j$, $d=d_j$, $v=v_j(\mathsf{aid})$, and the expected root comes from the manifest. These values are therefore omitted.
+The RSMST construction and hashing rules are defined in Appendix~\ref{app:rsmst}.  For a split allocation leaf, $k=\mathsf{id}_j$, $d=d_j$, $v=v_j(\mathsf{aid})$, and the expected root hash comes from the manifest.  These values are therefore omitted from the encoded proof and supplied by the verifier.
 
-A compact SMST inclusion proof is a two-element CBOR array:
+An encoded split allocation proof is a CBOR array of zero to 256 sibling entries, ordered leaf-to-root.  The empty array is valid only when the allocation tree for that asset contains a single output leaf.
 
-\begin{longtable}{clp{9cm}}
-\textbf{Index} & \textbf{Type} & \textbf{Description} \\
-\hline
-0 & byte string & Leaf path segment $p_1$, encoded as a minimal unsigned big-endian integer. \\
-1 & CBOR array & One or more sibling steps, ordered leaf-to-root. \\
-\end{longtable}
-
-Each sibling step is a three-element CBOR array:
+Each sibling entry is a three-element CBOR array:
 
 \begin{longtable}{clp{9cm}}
 \textbf{Index} & \textbf{Type} & \textbf{Description} \\
 \hline
-0 & byte string & Path segment $p_i$ for this parent, encoded as a minimal unsigned big-endian integer. \\
-1 & byte string or \texttt{null} & Sibling subtree hash $s_i$; a hash is the raw 32-byte SHA-256 digest. \\
-2 & byte string & Sibling subtree sum $w_i$, minimally encoded. \\
+0 & unsigned integer & Parent bifurcation depth $\delta_i$, with $0\leq\delta_i\leq255$. \\
+1 & byte string & Sibling subtree hash $s_i$, the raw 32-byte SHA-256 digest. \\
+2 & byte string & Positive sibling subtree sum $w_i$, minimally encoded. \\
 \end{longtable}
 
-Zero is encoded by the empty byte string and every positive path segment MUST NOT begin with \texttt{0x00}. Each path segment is positive and at most 33 bytes. A proof contains a leaf and between one and 256 sibling steps; its final parent segment MUST be $p_n=1$, the fixed SMST root label. The decoded path segments are interpreted using the LSB-first SMST path representation and concatenation operation defined in Appendix~\ref{app:smst}; decoders MUST reject zero segments, non-minimal encodings, paths whose reconstructed length exceeds the split key-path length, or any reconstructed path other than the expected key path. The pair $(s_i,w_i)$ is canonical: $s_i=\bot$ if and only if $w_i=0$. No root hash, asset identifier, output identifier, leaf data or leaf amount occurs in the encoded proof.
+Depths MUST be strictly decreasing in proof order.  Decoders MUST reject non-minimal CBOR integers, depths outside $0,\ldots,255$, repeated or non-decreasing depths, sibling hashes whose length is not 32 bytes, zero sibling sums, overlong or non-minimal sum encodings, or more than 256 sibling entries.  No bitmap, path segment, root hash, asset identifier, output identifier, leaf data or leaf amount occurs in the encoded proof.
 
-For a 32-byte key $k$, define $\Call{smst\_key\_path}{k}$ as the positive integer whose minimal big-endian representation is $\mathtt{0x01}\|k$. Under the SMST LSB-first path representation, this is the 256 key bits followed by the root sentinel bit; the sentinel preserves leading zero bits of $k$ and fixes the split key path length to 257 bits.
-
-\subsubsection{Function $\textsc{smst\_verify\_compact}$}\label{sec:smst-verify-compact}
+\subsubsection{Function $\textsc{rsmst\_verify\_inclusion}$}\label{sec:rsmst-split-verify}
 
 \textbf{Input}:
 \begin{enumerate}
 	\item $k \in \bytes{32}$ -- expected output token identifier;
 	\item $d \in \bytes{32}$ -- expected output commitment;
 	\item $v \in \mathbb{N}$, $1\leq v<2^{256}$ -- expected output amount;
-	\item $\bar C=(p_1,\langle(p_2,s_2,w_2),\ldots,(p_n,s_n,w_n)\rangle)$ -- compact proof; and
+	\item $C^\mathsf{inc}=\langle(\delta_1,s_1,w_1),\ldots,(\delta_n,s_n,w_n)\rangle$ -- split allocation proof; and
 	\item $r \in \bytes{32}$ -- expected raw root digest from the manifest.
 \end{enumerate}
 
 \textbf{Output}: $(b,v_\mathsf{root}) \in \bool\times\mathbb{N}$, where $b$ is the success flag and $v_\mathsf{root}$ is the reconstructed root sum.
 
-\begin{algorithmic}
-	\Function{smst\_verify\_compact}{$k,d,v,\bar C,r$}
-		\If{$v=0$, $v\geq2^{256}$, $n<2$, $n>257$, $p_n\ne1$, or any field is non-canonical} \State \Return $(\FALSE,0)$ \EndIf
-		\State $h \gets \Call{smst\_leaf\_hash}{p_1,d,v}$
-		\State $v_\mathsf{sum} \gets v$
-		\State $q \gets p_1$
-		\State $p \gets p_1$
-		\For{$i \gets 2$ to $n$}
-			\If{$s_i=\bot$ and $w_i\ne0$, or $s_i\ne\bot$ and $w_i=0$}
-				\State \Return $(\FALSE,0)$
-			\EndIf
-			\State $v' \gets v_\mathsf{sum}+w_i$ using checked 256-bit addition; on overflow return $(\FALSE,0)$
-			\If{the rightmost bit of $p$ is $0$}
-				\State $(h',v'') \gets \Call{smst\_branch\_hash}{p_i,(h,v_\mathsf{sum}),(s_i,w_i)}$
-			\Else
-				\State $(h',v'') \gets \Call{smst\_branch\_hash}{p_i,(s_i,w_i),(h,v_\mathsf{sum})}$
-			\EndIf
-			\If{$v''\ne v'$} \State \Return $(\FALSE,0)$ \EndIf
-			\State $h \gets h'$
-			\State $v_\mathsf{sum} \gets v'$
-			\State $q \gets q\|p_i$
-			\State $p \gets p_i$
-		\EndFor
-		\State \Return $((h=r)\land(q=\Call{smst\_key\_path}{k}),v_\mathsf{sum})$
-	\EndFunction
-\end{algorithmic}
-
-An implementation MUST NOT accept a hash match without also checking the reconstructed key path. It MUST reject an overflowing intermediate sum before invoking a big-integer implementation that could silently accept values outside the 256-bit amount domain.
+The verifier uses Appendix~\ref{sec:rsmst-verify-inclusion}.  It MUST reject an overflowing intermediate sum before invoking a big-integer implementation that could silently accept values outside the 256-bit amount domain.
 
 \subsection{Split Mint Reason}\label{app:split-mint-reason}
 
@@ -413,7 +377,7 @@ The mint-reason byte string of a split output contains CBOR semantic tag \texttt
 \textbf{Index} & \textbf{Type} & \textbf{Description} \\
 \hline
 0 & CBOR structure & Complete burned source token $\mathcal{L}_\mathsf{burn}$, including its certified manifest-bearing burn transfer. \\
-1 & CBOR array & Compact SMST proofs, one per output asset in canonical output-asset order. \\
+1 & CBOR array & Split allocation proofs, one per output asset in canonical output-asset order. \\
 \end{longtable}
 
 The proof array contains no asset identifiers. Its length and positional interpretation are determined exclusively by $\Call{Assets}{\mathsf{ty}_j,\auxd'_j}$.
@@ -438,19 +402,19 @@ The proof array contains no asset identifiers. Its length and positional interpr
 				\State $d_j\gets\Call{split\_output\_commitment}{\mathcal{L}.\mathsf{id},D_{\mathsf{out},j}}$
 			\EndFor
 			\ForAll{$(\mathsf{aid}_i,v_i)\in\mathcal{A}$ in canonical order}
-				\State $\mathcal{S}_i\gets$ empty SMST
+				\State $\mathcal{S}_i\gets$ empty RSMST
 				\For{$j\gets1$ to $k$}
 					\If{$(\mathsf{aid}_i,v_{i,j})\in\mathcal{A}_j$}
 						\State insert $(\mathsf{id}_j,d_j,v_{i,j})$ into $\mathcal{S}_i$
 					\EndIf
 				\EndFor
-				\State $(r_i,v'_i)\gets\Call{SMSTRoot}{\mathcal{S}_i}$
+				\State $(r_i,v'_i)\gets\Call{RSMSTRoot}{\mathcal{S}_i}$
 				\State ensure($v'_i=v_i$)
 			\EndFor
 			\State $b_\mathcal{M}\gets\Call{EncodeSplitManifest}{\langle r_1,\ldots,r_m\rangle}$
 			\State construct burn transfer with auxiliary data $b_\mathcal{M}$ and recipient $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$
 			\For{$j\gets1$ to $k$}
-				\State $P_j\gets\langle\Call{CompactPath}{\mathcal{S}_i,\mathsf{id}_j}\mid(\mathsf{aid}_i,\_)\in\mathcal{A}_j\rangle$
+				\State $P_j\gets\langle\Call{RSMSTPath}{\mathcal{S}_i,\mathsf{id}_j}\mid(\mathsf{aid}_i,\_)\in\mathcal{A}_j\rangle$
 			\EndFor
 			\State durably persist $b_\mathcal{M}$, the burn transfer, and every $(D_{\mathsf{out},j},P_j)$
 			\State certify the burn and obtain $\mathcal{L}_\mathsf{burn}$
@@ -490,7 +454,7 @@ The following algorithm runs as the token-type-specific mint-reason check after 
 			\For{$\ell\gets1$ to $\len{\mathcal{A}_j}$}
 				\State $(\mathsf{aid},v)\gets\mathcal{A}_j[\ell]$
 				\State $i\gets$ the unique index with $\mathcal{A}[i].\mathsf{aid}=\mathsf{aid}$; ensure it exists
-				\State $(b,v_\mathsf{root})\gets\Call{smst\_verify\_compact}{\mathsf{id}_j,d_j,v,P_j[\ell],r_i}$
+				\State $(b,v_\mathsf{root})\gets\Call{rsmst\_verify\_inclusion}{\mathsf{id}_j,d_j,v,P_j[\ell],r_i}$
 				\State ensure($b=\TRUE$)
 				\State ensure($v_\mathsf{root}=\mathcal{A}[i].v$)
 			\EndFor

--- a/appendix-token.tex
+++ b/appendix-token.tex
@@ -273,7 +273,7 @@ All standard predicates that verify digital signatures ($\predi_\mathsf{sig}$, $
 
 \section{Split Proof Encoding}\label{app:split-proof-encoding}
 
-This section specifies version~2 of the split mint reason described in Sec.~\ref{sec:token-splitting}.
+This section specifies the split mint reason described in Sec.~\ref{sec:token-splitting}. The split manifest and mint reason are identified by their distinct CBOR semantic tags.
 
 \subsection{Canonical Assets and Limits}
 
@@ -281,7 +281,7 @@ The token-type-specific function $\Call{Assets}{\mathsf{ty},\auxd'}$ returns a s
 \[
 \langle(\mathsf{aid}_1,v_1),\ldots,(\mathsf{aid}_m,v_m)\rangle
 \]
-strictly ordered by the raw bytes of $\mathsf{aid}_i$ using unsigned lexicographic comparison, with a shorter byte string ordered first when it is a prefix of another. Split version~2 requires:
+strictly ordered by the raw bytes of $\mathsf{aid}_i$ using unsigned lexicographic comparison, with a shorter byte string ordered first when it is a prefix of another. The split protocol requires:
 \begin{itemize}
 	\item $1 \leq m \leq 256$;
 	\item $1 \leq \len{\mathsf{aid}_i} \leq 128$ bytes;
@@ -290,11 +290,11 @@ strictly ordered by the raw bytes of $\mathsf{aid}_i$ using unsigned lexicograph
 \end{itemize}
 Amounts and SMST sums are encoded as minimal unsigned big-endian byte strings of at most 32 bytes. Zero is encoded by the empty byte string. An accepted non-empty integer encoding MUST NOT begin with \texttt{0x00}.
 
-All structures below use deterministic CBOR and must be consumed completely. Decoders MUST reject indefinite-length items, non-minimal heads or integers, wrong tags, unknown versions, wrong field counts or types, trailing bytes, duplicate or unordered assets, invalid lengths, arithmetic overflow, and exhausted cumulative byte, item, nesting, proof-step or embedded-token budgets.
+All structures below use deterministic CBOR and must be consumed completely. Decoders MUST reject indefinite-length items, non-minimal heads or integers, wrong or unknown tags, wrong field counts or types, trailing bytes, duplicate or unordered assets, invalid lengths, arithmetic overflow, and exhausted cumulative byte, item, nesting, proof-step or embedded-token budgets.
 
 \subsection{Output Commitment}\label{app:split-output-commitment}
 
-The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Define $\mathsf{SPLIT\_OUTPUT\_V2}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT\_V2}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
+The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Define $\mathsf{SPLIT\_OUTPUT}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
 \[
 D_{\mathsf{mint},j}
 =(\alpha,\predi'_j,\mathsf{salt}_j,\mathsf{ty}_j,
@@ -305,7 +305,7 @@ derive
 \begin{split}
 \mathsf{id}_j &:= H(\mathsf{salt}_j,\alpha),\\
 d_j &:= \mathsf{SHA\text{-}256}\bigl(\mathsf{CBOR}(
-  \mathsf{SPLIT\_OUTPUT\_V2},
+  \mathsf{SPLIT\_OUTPUT},
   \mathsf{id}_\mathsf{src},
   \alpha,
   \encpred(\predi'_j),
@@ -320,14 +320,12 @@ Every term is encoded as a CBOR byte string except $\alpha$, which is an unsigne
 
 \subsection{Split Manifest}\label{app:split-manifest}
 
-The final transfer of the source token stores a split manifest in its auxiliary-data byte string. The byte string contains CBOR semantic tag \texttt{39046} applied to the following two-element array:
+The final transfer of the source token stores a split manifest in its auxiliary-data byte string. The byte string contains CBOR semantic tag \texttt{39046} applied directly to an array of SMST root hashes:
 
-\begin{longtable}{clp{9cm}}
-\textbf{Index} & \textbf{Type} & \textbf{Description} \\
-\hline
-0 & unsigned integer & Split-manifest version; MUST equal $2$. \\
-1 & CBOR array & Ordered SMST root hashes $\langle r_1,\ldots,r_m\rangle$; each $r_i$ is the raw 32-byte SHA-256 digest. \\
-\end{longtable}
+\[
+\langle r_1,\ldots,r_m\rangle.
+\]
+Each $r_i$ is encoded as a byte string containing the raw 32-byte SHA-256 digest.
 
 The roots are positionally aligned with $\Call{Assets}{\mathsf{ty}_\mathsf{src},\auxd'_\mathsf{src}}$ in canonical asset order. The array length MUST equal the source asset count. Asset identifiers and source amounts are not repeated in the manifest.
 
@@ -409,14 +407,13 @@ An implementation MUST NOT accept a hash match without also checking the reconst
 
 \subsection{Split Mint Reason}\label{app:split-mint-reason}
 
-The mint-reason byte string of a split output contains CBOR semantic tag \texttt{39044} applied to this three-element array:
+The mint-reason byte string of a split output contains CBOR semantic tag \texttt{39044} applied to this two-element array:
 
 \begin{longtable}{clp{9cm}}
 \textbf{Index} & \textbf{Type} & \textbf{Description} \\
 \hline
-0 & unsigned integer & Split mint-reason version; MUST equal $2$. \\
-1 & CBOR structure & Complete burned source token $\mathcal{L}_\mathsf{burn}$, including its certified manifest-bearing burn transfer. \\
-2 & CBOR array & Compact SMST proofs, one per output asset in canonical output-asset order. \\
+0 & CBOR structure & Complete burned source token $\mathcal{L}_\mathsf{burn}$, including its certified manifest-bearing burn transfer. \\
+1 & CBOR array & Compact SMST proofs, one per output asset in canonical output-asset order. \\
 \end{longtable}
 
 The proof array contains no asset identifiers. Its length and positional interpretation are determined exclusively by $\Call{Assets}{\mathsf{ty}_j,\auxd'_j}$.
@@ -424,7 +421,7 @@ The proof array contains no asset identifiers. Its length and positional interpr
 \subsection{Split Construction Algorithm}\label{app:split-construction}
 
 \begin{algorithm}[!htbp]
-	\caption{Split Construction (Version 2)}\label{alg:split-construction-v2}
+	\caption{Split Construction}\label{alg:split-construction}
 	\begin{algorithmic}[0]
 		\Function{ConstructSplit}{$\mathcal{L},\langle D_{\mathsf{out},1},\ldots,D_{\mathsf{out},k}\rangle,\mathcal{T}$}
 			\State ensure($\Call{VerifyToken}{\mathcal{L},\mathcal{T}}=1$)
@@ -449,7 +446,7 @@ The proof array contains no asset identifiers. Its length and positional interpr
 				\State $(r_i,v'_i)\gets\Call{SMSTRoot}{\mathcal{S}_i}$
 				\State ensure($v'_i=v_i$)
 			\EndFor
-			\State $b_\mathcal{M}\gets\Call{EncodeSplitManifest}{2,\langle r_1,\ldots,r_m\rangle}$
+			\State $b_\mathcal{M}\gets\Call{EncodeSplitManifest}{\langle r_1,\ldots,r_m\rangle}$
 			\State construct burn transfer with auxiliary data $b_\mathcal{M}$ and recipient $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$
 			\For{$j\gets1$ to $k$}
 				\State $P_j\gets\langle\Call{CompactPath}{\mathcal{S}_i,\mathsf{id}_j}\mid(\mathsf{aid}_i,\_)\in\mathcal{A}_j\rangle$
@@ -457,7 +454,7 @@ The proof array contains no asset identifiers. Its length and positional interpr
 			\State durably persist $b_\mathcal{M}$, the burn transfer, and every $(D_{\mathsf{out},j},P_j)$
 			\State certify the burn and obtain $\mathcal{L}_\mathsf{burn}$
 			\For{$j\gets1$ to $k$}
-				\State $\mathsf{reason}_j\gets\Call{EncodeSplitReason}{2,\mathcal{L}_\mathsf{burn},P_j}$
+				\State $\mathsf{reason}_j\gets\Call{EncodeSplitReason}{\mathcal{L}_\mathsf{burn},P_j}$
 			\EndFor
 			\State \Return the burn transfer and output mint data with reasons $\mathsf{reason}_j$
 		\EndFunction
@@ -471,15 +468,15 @@ The caller MUST persist all output mint fields and proofs before submitting the 
 The following algorithm runs as the token-type-specific mint-reason check after normal verification of the output's certified mint transaction. Recursive calls share the same trust base, verifier registry, issuance policy and cumulative resource budget.
 
 \begin{algorithm}[!htbp]
-	\caption{Split Mint-Reason Verification (Version 2)}\label{alg:split-verify-v2}
+	\caption{Split Mint-Reason Verification}\label{alg:split-verify}
 	\begin{algorithmic}[0]
 		\Function{VerifySplitReason}{$D_{\mathsf{mint},j},\mathcal{T},\mathsf{context}$}
-			\State $(2,\mathcal{L}_\mathsf{burn},P_j)\gets\Call{DecodeSplitReason}{D_{\mathsf{mint},j}.\mathsf{reason}}$
+			\State $(\mathcal{L}_\mathsf{burn},P_j)\gets\Call{DecodeSplitReason}{D_{\mathsf{mint},j}.\mathsf{reason}}$
 			\State ensure($\Call{VerifyToken}{\mathcal{L}_\mathsf{burn},\mathcal{T},\mathsf{context}}=1$)
 			\State ensure($\mathcal{L}_\mathsf{burn}.\alpha=D_{\mathsf{mint},j}.\alpha=\mathcal{T}.\alpha$)
 			\State $T_\mathsf{burn}\gets$ final certified transfer of $\mathcal{L}_\mathsf{burn}$
 			\State $b_\mathcal{M}\gets T_\mathsf{burn}.\auxd'$
-			\State $(2,\langle r_1,\ldots,r_m\rangle)\gets\Call{DecodeSplitManifest}{b_\mathcal{M}}$
+			\State $\langle r_1,\ldots,r_m\rangle\gets\Call{DecodeSplitManifest}{b_\mathcal{M}}$
 			\State ensure($T_\mathsf{burn}.\predi'=\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$)
 			\State $D_\mathsf{src}\gets\mathcal{L}_\mathsf{burn}.T_0.D_\mathsf{mint}$
 			\State $\mathcal{A}\gets\Call{Assets}{D_\mathsf{src}.\mathsf{ty},D_\mathsf{src}.\auxd'}$

--- a/appendix-token.tex
+++ b/appendix-token.tex
@@ -294,7 +294,7 @@ All structures below use deterministic CBOR and must be consumed completely. Dec
 
 \subsection{Output Commitment}\label{app:split-output-commitment}
 
-The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Split verification additionally requires the output token type to equal the source token type byte-for-byte; including $\mathsf{ty}_j$ in this commitment prevents replay of a prepared proof under any other mint transaction. Define $\mathsf{SPLIT\_OUTPUT}$ as the ASCII byte string \texttt{UNICITY\_SPLIT\_OUTPUT}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
+The output commitment binds an allocation leaf to the complete output mint transaction except for its mint reason. Split verification additionally requires the output token type to equal the source token type byte-for-byte; including $\mathsf{ty}_j$ in this commitment prevents replay of a prepared proof under any other mint transaction. Define $\mathsf{SPLIT\_OUTPUT}$ as the ASCII byte string \texttt{"UNICITY\_SPLIT\_OUTPUT"}. For source identifier $\mathsf{id}_\mathsf{src}$ and output mint data
 \[
 D_{\mathsf{mint},j}
 =(\alpha,\predi'_j,\mathsf{salt}_j,\mathsf{ty}_j,

--- a/execution-layer.tex
+++ b/execution-layer.tex
@@ -481,7 +481,7 @@ where a missing entry has value zero.  No output may introduce an asset identifi
 
 For output $j$, let $D_{\mathsf{out},j}$ consist of the source token identifier and all output mint fields except the mint reason.  Its commitment
 \[
-d_j = H(\mathsf{SPLIT\_OUTPUT\_V2},D_{\mathsf{out},j})
+d_j = H(\mathsf{SPLIT\_OUTPUT},D_{\mathsf{out},j})
 \]
 binds the allocation to the source token, network, recipient predicate, salt and resulting token identifier, token type, and the complete canonical auxiliary payload.  In particular, a proof prepared for one recipient or token type cannot authorize a mint to another, even though the standard minting key is public.
 
@@ -507,7 +507,7 @@ The split proceeds as follows:
 
 Given a token whose mint reason claims split origin, the verifier must perform all of the following checks.  Failure of any check rejects the token.
 \begin{enumerate}
-	\item Decode the mint reason, manifest, payloads and proofs using deterministic CBOR.  Reject unknown versions or tags, non-canonical integers or byte strings, duplicate or unordered asset identifiers, invalid field counts or types, trailing bytes, arithmetic overflow and any input exceeding the protocol's decoding and verification limits.
+	\item Decode the mint reason, manifest, payloads and proofs using deterministic CBOR.  Reject wrong or unknown tags, non-canonical integers or byte strings, duplicate or unordered asset identifiers, invalid field counts or types, trailing bytes, arithmetic overflow and any input exceeding the protocol's decoding and verification limits.
 	\item Verify the output mint transaction and its Unicity Certificate.  Decode and validate its auxiliary payload according to its token type; the payload must contain a non-empty canonical collection of distinct, positive-valued assets.
 	\item Recursively verify the complete burned source token, including every Unicity Certificate, transaction, nested mint reason, fungible payload and token type specific issuance policy, under the same trust base $\mathcal{T}$, verifier registry and cumulative resource limits used for the output.  Both tokens must have network identifier $\mathcal{T}.\alpha$.
 	\item Require the source token to end in a certified transfer whose auxiliary data is the exact canonical split-manifest encoding $b_\mathcal{M}$ and whose recipient predicate is exactly $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$.

--- a/execution-layer.tex
+++ b/execution-layer.tex
@@ -294,7 +294,7 @@ The \emph{burn predicate} $\predi_\mathsf{burn}(h_\mathsf{reason})$ cannot be un
 	\item \textbf{Definition}: $\predi_\mathsf{burn}(h_\mathsf{reason}; \tau, m, u) = 0$ for all arguments
 \end{itemize}
 
-The burn predicate is used in token splitting (Sec.~\ref{sec:token-splitting}), where the reason hash references the aggregation root of the split proof.
+The burn predicate is used in token splitting (Sec.~\ref{sec:token-splitting}), where the reason hash is $\mathsf{SHA\text{-}256}(b_\mathcal{M})$ for the complete canonical split-manifest encoding $b_\mathcal{M}$.
 
 
 \subsubsection{Timelock Predicate}
@@ -473,7 +473,7 @@ Let $\Call{Assets}{\mathsf{ty},\auxd'}$ denote the token-type-specific, determin
 \[
 \mathcal{A}=\Call{Assets}{\mathsf{ty},\auxd'},
 \]
-the owner prepares $k \geq 1$ output mint transactions on the same network, with canonical asset collections $\mathcal{A}_1,\ldots,\mathcal{A}_k$.  For every source asset identifier $\mathsf{aid}$ the allocations must satisfy
+the owner prepares $k \geq 1$ output mint transactions on the same network and with exactly the same token type $\mathsf{ty}$, with canonical asset collections $\mathcal{A}_1,\ldots,\mathcal{A}_k$.  Splitting is not a token-type conversion mechanism.  For every source asset identifier $\mathsf{aid}$ the allocations must satisfy
 \[
 \sum_{j=1}^{k} v_j(\mathsf{aid}) = v(\mathsf{aid})
 \]
@@ -512,6 +512,7 @@ Given a token whose mint reason claims split origin, the verifier must perform a
 	\item Recursively verify the complete burned source token, including every Unicity Certificate, transaction, nested mint reason, fungible payload and token type specific issuance policy, under the same trust base $\mathcal{T}$, verifier registry and cumulative resource limits used for the output.  Both tokens must have network identifier $\mathcal{T}.\alpha$.
 	\item Require the source token to end in a certified transfer whose auxiliary data is the exact canonical split-manifest encoding $b_\mathcal{M}$ and whose recipient predicate is exactly $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$.
 	\item Decode the source fungible payload, place its distinct asset identifiers in canonical order, and require the manifest to contain exactly one root hash for each source asset in that order.
+	\item Require the output token type to be byte-identical to the source token type.  A split proof cannot authorize minting under any other token type, even if that type would decode the same asset identifiers and amounts.
 	\item Recompute $d_j$ from the verified source identifier and the output mint fields other than $\mathsf{reason}$.  The recomputation must cover the exact canonical recipient predicate, network, salt, token identifier, token type and complete auxiliary payload.
 	\item Require the proof count to equal the number of assets in the output payload.  Associate proofs with assets only by their canonical order; reject missing, duplicate or additional proofs.
 	\item For every output asset $(\mathsf{aid}_i,v_j(\mathsf{aid}_i))$, require that $\mathsf{aid}_i$ occurs in the source payload.  Verify its compact SMST proof using key $\mathsf{id}_j$, leaf data $d_j$, leaf value $v_j(\mathsf{aid}_i)$ and expected root $r_i$ selected from the manifest.  Require both inclusion and root-hash equality.

--- a/execution-layer.tex
+++ b/execution-layer.tex
@@ -445,7 +445,7 @@ An \emph{asset} is a pair $(\mathsf{aid}, v)$, where:
 
 A token may carry multiple assets, represented as a collection:
 \[
-\mathcal{A} = \{(\mathsf{aid}_1, v_1), \ldots, (\mathsf{aid}_k, v_k)\}
+\mathcal{A} = \{(\mathsf{aid}_1, v_1), \ldots, (\mathsf{aid}_m, v_m)\}
 \]
 where all asset identifiers $\mathsf{aid}_i$ are distinct.
 

--- a/execution-layer.tex
+++ b/execution-layer.tex
@@ -463,45 +463,69 @@ The token type identifier $\mathsf{ty}$ in the mint transaction classifies the t
 \subsection{Token Splitting}\label{sec:token-splitting}
 
 \index{token!splitting}
-Splitting allows a fungible token to be divided into multiple new tokens while provably preserving total value. The protocol uses \emph{Sparse Merkle Sum Trees}\index{Sparse Merkle Sum Tree} to provide cryptographic value conservation proofs.
+Splitting allows a fungible token to be divided into multiple new tokens while preserving the amount of every enclosed asset independently.  The protocol uses one \emph{Sparse Merkle Sum Tree}\index{Sparse Merkle Sum Tree} (SMST) per asset identifier.  An SMST commits both to every output allocation and to their sum, so verification of any output proves that its amount is included in a committed allocation whose total equals the source amount.
+
+Each fractional token is self-contained and carries the complete certified burned source token in its mint reason. Implementations may deduplicate identical source-token bytes internally.
 
 \subsubsection{Split Protocol}
 
-Given a token $\mathcal{L}$ bound to network identifier $\alpha$ and carrying asset collection $\mathcal{A}$, the owner splits it into $k$ new tokens on the same network $\alpha$ with respective asset allocations $\mathcal{A}_1, \ldots, \mathcal{A}_k$ such that for every asset identifier $\mathsf{aid}$:
+Let $\Call{Assets}{\mathsf{ty},\auxd'}$ denote the token-type-specific, deterministic decoding and validation of a fungible payload.  Asset identifiers in the resulting collection are non-empty, distinct and placed in canonical bytewise order, and every amount is positive.  A payload containing a zero-valued entry is rejected rather than normalized.  Given a valid token $\mathcal{L}$ on network $\alpha$ carrying
+\[
+\mathcal{A}=\Call{Assets}{\mathsf{ty},\auxd'},
+\]
+the owner prepares $k \geq 1$ output mint transactions on the same network, with canonical asset collections $\mathcal{A}_1,\ldots,\mathcal{A}_k$.  For every source asset identifier $\mathsf{aid}$ the allocations must satisfy
 \[
 \sum_{j=1}^{k} v_j(\mathsf{aid}) = v(\mathsf{aid})
 \]
-where $v(\mathsf{aid})$ is the original value and $v_j(\mathsf{aid})$ is the value allocated to token $j$.
+where a missing entry has value zero.  No output may introduce an asset identifier absent from $\mathcal{A}$.  Amounts of different asset identifiers are never added to or substituted for one another.
+
+For output $j$, let $D_{\mathsf{out},j}$ consist of the source token identifier and all output mint fields except the mint reason.  Its commitment
+\[
+d_j = H(\mathsf{SPLIT\_OUTPUT\_V2},D_{\mathsf{out},j})
+\]
+binds the allocation to the source token, network, recipient predicate, salt and resulting token identifier, token type, and the complete canonical auxiliary payload.  In particular, a proof prepared for one recipient or token type cannot authorize a mint to another, even though the standard minting key is public.
 
 The split proceeds as follows:
 \begin{enumerate}
-	\item For each asset identifier $\mathsf{aid} \in \mathcal{A}$, construct a \emph{Sparse Merkle Sum Tree} $\mathcal{S}_\mathsf{aid}$ with leaves keyed by new token identifiers $\mathsf{id}_j = H(\mathsf{salt}_j, \alpha)$ derived from distinct minter-chosen salts $\mathsf{salt}_j \in \{0,1\}^{256}$ (uniqueness among the minter's choices required; no masking role, no min-entropy requirement), and valued by the respective asset amounts $v_j(\mathsf{aid})$.
-	\item Construct an \emph{aggregation tree} $\mathcal{G}$ combining the root hashes of all per-asset sum trees.
-	\item \textbf{Burn the original token}: create a transfer transaction from $\mathcal{L}$ to the burn predicate $\predi_\mathsf{burn}(h_\mathsf{agg})$, where $h_\mathsf{agg}$ is the root hash of the aggregation tree $\mathcal{G}$. Certify this burn transaction via the Unicity Service.
-	\item \textbf{Mint each new token} $j \in \{1, \ldots, k\}$: create a mint transaction for token $\mathsf{id}_j$ on network $\alpha$ with $\mathsf{reason}$ set to a \emph{split reason proof} containing:
-	\begin{itemize}
-		\item The burned token $\mathcal{L}$ (complete history including the burn transaction)
-		\item An aggregation tree path proving that $\mathsf{aid}$ is part of the split
-		\item A sum tree path proving the value allocation $v_j(\mathsf{aid})$ and that the total value is conserved
-	\end{itemize}
+	\item Verify $\mathcal{L}$ completely, including its fungible payload, mint reason and issuer policy, before submitting any irreversible burn request.  Derive pairwise distinct output token identifiers $\mathsf{id}_j=H(\mathsf{salt}_j,\alpha)$ and the corresponding commitments $d_j$.
+	\item For every source asset $\mathsf{aid}_i$ in canonical order, construct an SMST $\mathcal{S}_i$.  For each output carrying that asset, insert the leaf
+	\[
+	(\mathsf{id}_j,d_j,v_j(\mathsf{aid}_i)).
+	\]
+	Require the SMST root sum to equal $v(\mathsf{aid}_i)$.  Let $r_i$ be its root hash.
+	\item Construct the \emph{split manifest}
+	\[
+	\mathcal{M}=\langle r_1,\ldots,r_m\rangle,
+	\]
+	where the roots are positionally aligned with the canonical source asset collection.  The manifest contains no repeated source identifier, asset identifiers or amounts: all are already authenticated by the burned token.  Its precise encoding $b_\mathcal{M}$ is defined in Appendix~\ref{app:split-proof-encoding}.  Extract and durably store every output's compact paths and mint fields, together with the manifest and complete burn-transfer fields, before proceeding.
+	\item Burn the source by creating and certifying a transfer whose auxiliary data is exactly $b_\mathcal{M}$ and whose recipient is $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$.  The resulting certified burned token is denoted $\mathcal{L}_\mathsf{burn}$.
+	\item Mint each output token $j$ with the exact fields committed by $d_j$.  Its mint reason contains $\mathcal{L}_\mathsf{burn}$ and, in canonical output-asset order, one compact SMST inclusion proof for every asset it carries.  The proof omits the asset identifier, output commitment, leaf amount and root hash because the verifier derives them respectively from the output payload, output mint transaction and split manifest.
 \end{enumerate}
+
 
 \subsubsection{Split Verification}\label{sec:split-verification}
 
-Given a new token claiming to originate from a split, the verifier checks:
+Given a token whose mint reason claims split origin, the verifier must perform all of the following checks.  Failure of any check rejects the token.
 \begin{enumerate}
-	\item The burned source token is valid and its last recipient is $\predi_\mathsf{burn}(h_\mathsf{agg})$
-	\item The new token and the burned source token verify under the same trust base $\mathcal{T}$; equivalently, both mint transaction network identifiers equal $\mathcal{T}.\alpha$
-	\item The aggregation tree path correctly leads to $h_\mathsf{agg}$
-	\item The sum tree path is valid: the leaf value matches the claimed asset amount, and the root sum equals the original token's value for this asset (value conservation)
+	\item Decode the mint reason, manifest, payloads and proofs using deterministic CBOR.  Reject unknown versions or tags, non-canonical integers or byte strings, duplicate or unordered asset identifiers, invalid field counts or types, trailing bytes, arithmetic overflow and any input exceeding the protocol's decoding and verification limits.
+	\item Verify the output mint transaction and its Unicity Certificate.  Decode and validate its auxiliary payload according to its token type; the payload must contain a non-empty canonical collection of distinct, positive-valued assets.
+	\item Recursively verify the complete burned source token, including every Unicity Certificate, transaction, nested mint reason, fungible payload and token type specific issuance policy, under the same trust base $\mathcal{T}$, verifier registry and cumulative resource limits used for the output.  Both tokens must have network identifier $\mathcal{T}.\alpha$.
+	\item Require the source token to end in a certified transfer whose auxiliary data is the exact canonical split-manifest encoding $b_\mathcal{M}$ and whose recipient predicate is exactly $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$.
+	\item Decode the source fungible payload, place its distinct asset identifiers in canonical order, and require the manifest to contain exactly one root hash for each source asset in that order.
+	\item Recompute $d_j$ from the verified source identifier and the output mint fields other than $\mathsf{reason}$.  The recomputation must cover the exact canonical recipient predicate, network, salt, token identifier, token type and complete auxiliary payload.
+	\item Require the proof count to equal the number of assets in the output payload.  Associate proofs with assets only by their canonical order; reject missing, duplicate or additional proofs.
+	\item For every output asset $(\mathsf{aid}_i,v_j(\mathsf{aid}_i))$, require that $\mathsf{aid}_i$ occurs in the source payload.  Verify its compact SMST proof using key $\mathsf{id}_j$, leaf data $d_j$, leaf value $v_j(\mathsf{aid}_i)$ and expected root $r_i$ selected from the manifest.  Require both inclusion and root-hash equality.
+	\item Require the root sum reconstructed by that proof to equal the source amount $v(\mathsf{aid}_i)$.  This equality is checked independently for every asset identifier and is the verifier-side value-conservation rule; successful construction by a wallet is not evidence of conservation.
 \end{enumerate}
+
+These checks establish that the source was authentic and irreversibly spent, the burn committed to the exact set of per-asset allocation roots, every accepted output and its ownership were fixed before the burn, and no accepted output can create value.  The protocol does not guarantee that every prepared output will subsequently be minted or delivered: failure to mint an output can destroy value but cannot transfer or inflate it.  The party performing the irreversible burn is responsible for durably retaining the manifest, output salts and proofs required to resume minting.
 
 \subsection{Burn Transaction}\label{sec:burn-transaction}
 
 \index{burn transaction}
 A \emph{burn transaction} is a transfer transaction where the recipient predicate is $\predi_\mathsf{burn}(h_\mathsf{reason})$ (Sec.~\ref{sec:burn-predicate}). Since the burn predicate cannot be unlocked, the token is permanently spent and cannot be transferred further.
 
-The reason hash $h_\mathsf{reason}$ links the burn to its purpose. In a split operation, it is the aggregation tree root hash, enabling verifiers of the resulting tokens to trace back to the burned source.
+The reason hash $h_\mathsf{reason}$ links the burn to its purpose. In a split operation, it is the hash of the complete canonical split-manifest encoding $b_\mathcal{M}$, enabling verifiers of the resulting tokens to bind the source burn to the exact ordered vector of per-asset allocation roots.
 
 
 \section{Private Transactions}\label{sec:private-transactions}

--- a/execution-layer.tex
+++ b/execution-layer.tex
@@ -463,7 +463,7 @@ The token type identifier $\mathsf{ty}$ in the mint transaction classifies the t
 \subsection{Token Splitting}\label{sec:token-splitting}
 
 \index{token!splitting}
-Splitting allows a fungible token to be divided into multiple new tokens while preserving the amount of every enclosed asset independently.  The protocol uses one \emph{Sparse Merkle Sum Tree}\index{Sparse Merkle Sum Tree} (SMST) per asset identifier.  An SMST commits both to every output allocation and to their sum, so verification of any output proves that its amount is included in a committed allocation whose total equals the source amount.
+Splitting allows a fungible token to be divided into multiple new tokens while preserving the amount of every enclosed asset independently.  The protocol uses one \emph{Radix Sparse Merkle Sum Tree}\index{Radix Sparse Merkle Sum Tree} (RSMST) per asset identifier.  An RSMST reuses the radix sparse Merkle tree structure with sums committed next to every child hash, so verification of any output proves that its amount is included in a committed allocation whose total equals the source amount.
 
 Each fractional token is self-contained and carries the complete certified burned source token in its mint reason. Implementations may deduplicate identical source-token bytes internally.
 
@@ -488,18 +488,18 @@ binds the allocation to the source token, network, recipient predicate, salt and
 The split proceeds as follows:
 \begin{enumerate}
 	\item Verify $\mathcal{L}$ completely, including its fungible payload, mint reason and issuer policy, before submitting any irreversible burn request.  Derive pairwise distinct output token identifiers $\mathsf{id}_j=H(\mathsf{salt}_j,\alpha)$ and the corresponding commitments $d_j$.
-	\item For every source asset $\mathsf{aid}_i$ in canonical order, construct an SMST $\mathcal{S}_i$.  For each output carrying that asset, insert the leaf
+	\item For every source asset $\mathsf{aid}_i$ in canonical order, construct an RSMST $\mathcal{S}_i$.  For each output carrying that asset, insert the leaf
 	\[
 	(\mathsf{id}_j,d_j,v_j(\mathsf{aid}_i)).
 	\]
-	Require the SMST root sum to equal $v(\mathsf{aid}_i)$.  Let $r_i$ be its root hash.
+	Require the RSMST root sum to equal $v(\mathsf{aid}_i)$.  Let $r_i$ be its root hash.
 	\item Construct the \emph{split manifest}
 	\[
 	\mathcal{M}=\langle r_1,\ldots,r_m\rangle,
 	\]
-	where the roots are positionally aligned with the canonical source asset collection.  The manifest contains no repeated source identifier, asset identifiers or amounts: all are already authenticated by the burned token.  Its precise encoding $b_\mathcal{M}$ is defined in Appendix~\ref{app:split-proof-encoding}.  Extract and durably store every output's compact paths and mint fields, together with the manifest and complete burn-transfer fields, before proceeding.
+	where the roots are positionally aligned with the canonical source asset collection.  The manifest contains no repeated source identifier, asset identifiers or amounts: all are already authenticated by the burned token.  Its precise encoding $b_\mathcal{M}$ is defined in Appendix~\ref{app:split-proof-encoding}.  Extract and durably store every output's RSMST proofs and mint fields, together with the manifest and complete burn-transfer fields, before proceeding.
 	\item Burn the source by creating and certifying a transfer whose auxiliary data is exactly $b_\mathcal{M}$ and whose recipient is $\predi_\mathsf{burn}(\mathsf{SHA\text{-}256}(b_\mathcal{M}))$.  The resulting certified burned token is denoted $\mathcal{L}_\mathsf{burn}$.
-	\item Mint each output token $j$ with the exact fields committed by $d_j$.  Its mint reason contains $\mathcal{L}_\mathsf{burn}$ and, in canonical output-asset order, one compact SMST inclusion proof for every asset it carries.  The proof omits the asset identifier, output commitment, leaf amount and root hash because the verifier derives them respectively from the output payload, output mint transaction and split manifest.
+	\item Mint each output token $j$ with the exact fields committed by $d_j$.  Its mint reason contains $\mathcal{L}_\mathsf{burn}$ and, in canonical output-asset order, one RSMST inclusion proof for every asset it carries.  The proof contains only leaf-to-root sibling entries $(\delta,s,w)$ with explicit bifurcation depth, sibling hash and sibling sum; it omits the asset identifier, output identifier, output commitment, leaf amount and root hash because the verifier derives them respectively from the output payload, mint transaction, and split manifest.
 \end{enumerate}
 
 
@@ -515,7 +515,7 @@ Given a token whose mint reason claims split origin, the verifier must perform a
 	\item Require the output token type to be byte-identical to the source token type.  A split proof cannot authorize minting under any other token type, even if that type would decode the same asset identifiers and amounts.
 	\item Recompute $d_j$ from the verified source identifier and the output mint fields other than $\mathsf{reason}$.  The recomputation must cover the exact canonical recipient predicate, network, salt, token identifier, token type and complete auxiliary payload.
 	\item Require the proof count to equal the number of assets in the output payload.  Associate proofs with assets only by their canonical order; reject missing, duplicate or additional proofs.
-	\item For every output asset $(\mathsf{aid}_i,v_j(\mathsf{aid}_i))$, require that $\mathsf{aid}_i$ occurs in the source payload.  Verify its compact SMST proof using key $\mathsf{id}_j$, leaf data $d_j$, leaf value $v_j(\mathsf{aid}_i)$ and expected root $r_i$ selected from the manifest.  Require both inclusion and root-hash equality.
+	\item For every output asset $(\mathsf{aid}_i,v_j(\mathsf{aid}_i))$, require that $\mathsf{aid}_i$ occurs in the source payload.  Verify its RSMST proof using key $\mathsf{id}_j$, leaf data $d_j$, leaf value $v_j(\mathsf{aid}_i)$ and expected root $r_i$ selected from the manifest.  Require both inclusion and root-hash equality.
 	\item Require the root sum reconstructed by that proof to equal the source amount $v(\mathsf{aid}_i)$.  This equality is checked independently for every asset identifier and is the verifier-side value-conservation rule; successful construction by a wallet is not evidence of conservation.
 \end{enumerate}
 

--- a/ndrsmt3o.py
+++ b/ndrsmt3o.py
@@ -26,13 +26,13 @@
 # by the committed keys.
 # This may result in leaves without valid inclusion proofs.
 #
-# Format (flat opcode stream from LSB-first post-order traversal):
+# Format (flat opcode stream from byte-order-preserving LSB-in-byte post-order traversal):
 #   'S' (Subtree): Stream: ['S', hash]. Represents an unmodified existing branch.
 #   'L' (Leaf):    Stream: ['L']. Denotes a newly inserted key-value pair.
 #   'N' (Node):    Stream: ['N', depth]. Two children precede (left, right).
 #
 # Verification Algorithm -- Eval(π, B) --> (h_0, h_1):
-#   1. Sort batch B by LSB-first traversal order (bit-reversed sort keys).
+#   1. Sort batch B by tree traversal order (bit-reversed bytes, byte order preserved).
 #   2. Initialize a result stack and iterators for π and sorted B.
 #   3. Scan tokens in π (stack machine, no recursion):
 #      - 'S': push (hash, hash).
@@ -106,7 +106,7 @@
 # Format:
 #   - bitmap: bit string (here 256-bit integer). Set bits indicate branch
 #             node depth positions.
-#   - siblings: Array of sibling hashes ordered leaf-to-root.
+#   - siblings: Array of sibling hashes ordered root-to-leaf.
 #
 # Security Argument:
 #   Theorem: The operator cannot produce an inclusion proof for a
@@ -147,10 +147,32 @@ BIT_REVERSE_TABLE = bytes(int(f"{i:08b}"[::-1], 2) for i in range(256))
 
 def get_sort_key(k):
     """
-    Converts integer key to LSB-first lexicographical sort key.
-    (Reverse byte order, then reverse bits in each byte).
+    Converts integer key to tree-traversal lexicographical sort key.
+    Byte order is preserved; bits are reversed within each byte so bit 0 of
+    byte 0 compares first.
     """
-    return k.to_bytes(KEY_BYTES, "big")[::-1].translate(BIT_REVERSE_TABLE)
+    return k.to_bytes(KEY_BYTES, "big").translate(BIT_REVERSE_TABLE)
+
+
+def traversal_key(k):
+    """
+    Internal integer whose bit d is bit (d % 8) of byte floor(d / 8) of k.
+
+    The public integer key is still serialized as a 32-byte big-endian value
+    for hashing. Reversing bytes only for this internal integer lets the
+    existing path-compressed arithmetic operate on the SDK RSMT bit order.
+    """
+    return int.from_bytes(k.to_bytes(KEY_BYTES, "big")[::-1], "big")
+
+
+def key_bit(k, depth):
+    return (traversal_key(k) >> depth) & 1
+
+
+def key_bits(k, start, length):
+    if length == 0:
+        return 0
+    return (traversal_key(k) >> start) & ((1 << length) - 1)
 
 
 def hash_leaf(key, value):
@@ -223,7 +245,7 @@ class SparseMerkleTree:
         """
         Batch insertion without consistency-proof generation.
 
-        The batch is sorted exactly once in LSB-first traversal order, then
+        The batch is sorted exactly once in tree traversal order, then
         merged against the touched search frontier of the tree. Existing keys
         are filtered during that merge, so this avoids the extra per-key
         membership probes done by the proof-producing path.
@@ -254,7 +276,7 @@ class SparseMerkleTree:
         low, high = start, end
         while low < high:
             mid = (low + high) // 2
-            if (batch[mid][0] >> split) & 1:
+            if key_bit(batch[mid][0], split):
                 high = mid
             else:
                 low = mid + 1
@@ -281,12 +303,12 @@ class SparseMerkleTree:
             k, v, _ = batch[start]
             return LeafBranch(k, v)
 
-        xor = (batch[start][0] ^ batch[end - 1][0]) >> start_bit
+        xor = (traversal_key(batch[start][0]) ^ traversal_key(batch[end - 1][0])) >> start_bit
         split = start_bit + (xor & -xor).bit_length() - 1
         mid = self._partition_point_np(batch, start, end, split)
 
         n_common = split - start_bit
-        cp = (1 << n_common) | ((batch[start][0] >> start_bit) & ((1 << n_common) - 1))
+        cp = (1 << n_common) | key_bits(batch[start][0], start_bit, n_common)
 
         ln = self._build_subtree_np(batch, start, mid, split)
         rn = self._build_subtree_np(batch, mid, end, split)
@@ -309,10 +331,10 @@ class SparseMerkleTree:
         node_prefix = node.path & ((1 << n_path) - 1)
 
         first_div = n_path
-        xor_start = ((batch[start][0] >> start_bit) & ((1 << n_path) - 1)) ^ node_prefix
+        xor_start = key_bits(batch[start][0], start_bit, n_path) ^ node_prefix
         if xor_start:
             first_div = min(first_div, (xor_start & -xor_start).bit_length() - 1)
-        xor_end = ((batch[end - 1][0] >> start_bit) & ((1 << n_path) - 1)) ^ node_prefix
+        xor_end = key_bits(batch[end - 1][0], start_bit, n_path) ^ node_prefix
         if xor_end:
             first_div = min(first_div, (xor_end & -xor_end).bit_length() - 1)
 
@@ -380,20 +402,20 @@ class SparseMerkleTree:
             return LeafBranch(k, v)
 
         # O(1) split-point from extremes, O(log N) binary search partition
-        xor = (batch[start][0] ^ batch[end - 1][0]) >> start_bit
+        xor = (traversal_key(batch[start][0]) ^ traversal_key(batch[end - 1][0])) >> start_bit
         split = start_bit + (xor & -xor).bit_length() - 1
 
         low, high = start, end
         while low < high:
             mid = (low + high) // 2
-            if (batch[mid][0] >> split) & 1:
+            if key_bit(batch[mid][0], split):
                 high = mid
             else:
                 low = mid + 1
         mid = low
 
         n_common = split - start_bit
-        cp = (1 << n_common) | ((batch[start][0] >> start_bit) & ((1 << n_common) - 1))
+        cp = (1 << n_common) | key_bits(batch[start][0], start_bit, n_common)
 
         ln = self._build_subtree(batch, start, mid, split, proof_out, frozen)
         rn = self._build_subtree(batch, mid, end, split, proof_out, frozen)
@@ -421,10 +443,10 @@ class SparseMerkleTree:
 
         # O(1) checks to see if the batch bounds diverge from the node path
         first_div = n_path
-        xor_start = ((batch[start][0] >> start_bit) & ((1 << n_path) - 1)) ^ node_prefix
+        xor_start = key_bits(batch[start][0], start_bit, n_path) ^ node_prefix
         if xor_start:
             first_div = min(first_div, (xor_start & -xor_start).bit_length() - 1)
-        xor_end = ((batch[end - 1][0] >> start_bit) & ((1 << n_path) - 1)) ^ node_prefix
+        xor_end = key_bits(batch[end - 1][0], start_bit, n_path) ^ node_prefix
         if xor_end:
             first_div = min(first_div, (xor_end & -xor_end).bit_length() - 1)
 
@@ -438,7 +460,7 @@ class SparseMerkleTree:
         low, high = start, end
         while low < high:
             mid = (low + high) // 2
-            if (batch[mid][0] >> split) & 1:
+            if key_bit(batch[mid][0], split):
                 high = mid
             else:
                 low = mid + 1
@@ -468,7 +490,7 @@ class SparseMerkleTree:
         low, high = start, end
         while low < high:
             mid = (low + high) // 2
-            if (batch[mid][0] >> new_split) & 1:
+            if key_bit(batch[mid][0], new_split):
                 high = mid
             else:
                 low = mid + 1
@@ -491,10 +513,10 @@ class SparseMerkleTree:
             if isinstance(node, LeafBranch):
                 return node if node.key == key else None
             n = path_len(node.path)
-            if ((key >> bit) & ((1 << n) - 1)) != (node.path & ((1 << n) - 1)):
+            if key_bits(key, bit, n) != (node.path & ((1 << n) - 1)):
                 return None
             bit += n
-            node = node.right if ((key >> bit) & 1) else node.left
+            node = node.right if key_bit(key, bit) else node.left
         return None
 
 
@@ -511,11 +533,11 @@ class SparseMerkleTree:
         while isinstance(node, NodeBranch):
             n = path_len(node.path)
             prefix = node.path & ((1 << n) - 1)
-            if ((key >> bit) & ((1 << n) - 1)) != prefix:
+            if key_bits(key, bit, n) != prefix:
                 return None  # key not in tree
             bit += n
             depth = node.depth
-            if (key >> bit) & 1:
+            if key_bit(key, bit):
                 siblings.append(node.left.get_hash())
                 node = node.right
             else:
@@ -611,7 +633,7 @@ def verify_inclusion(cert, root_hash, key, value):
         if j < 0:
             return False
         s = siblings[j]
-        if (key >> d) & 1:
+        if key_bit(key, d):
             h = hash_node(s, h, d)
         else:
             h = hash_node(h, s, d)

--- a/unicity-data-structs.abnf
+++ b/unicity-data-structs.abnf
@@ -188,10 +188,44 @@
 
 ; --- Fungible Token Structures ---
   Asset = AssetId Value  ;~$(\mathsf{aid}, v)$ -- CBOR array[2]
-  AssetId = Bytes  ;~asset type identifier
-  Value = Bytes  ;~non-negative integer (bigint-encoded)
+  AssetCollection = 1*256Asset
+      ;~canonical CBOR array, strictly ordered by raw $\mathsf{aid}$ bytes
+  AssetId = 1*128OCTET  ;~non-empty asset type identifier
+  Value = 1*32OCTET
+      ;~$1 \leq v < 2^{256}$, minimal unsigned big-endian byte string
 
-  SplitReason = Token *SplitReasonProof  ;~CBOR array[2]: [burned source token, [proofs...]]
-  SplitReasonProof = AssetId AggregationPath AssetTreePath  ;~$(\mathsf{aid}, \pi_\mathsf{agg}, \pi_\mathsf{sum})$ -- CBOR array[3]
-  AggregationPath = SparseMerkleTreePath   ;~SMT path to aggregation root $h_\mathsf{agg}$
-  AssetTreePath = SparseMerkleSumTreePath  ;~SMST path proving value allocation
+  ; Split protocol version 2. These productions describe the decoded tagged
+  ; CBOR values. SplitManifestBytes and SplitMintReasonBytes are the complete
+  ; deterministic tagged encodings carried in transaction byte-string fields.
+
+  SplitManifestBytes = Bytes
+      ;~CBOR tag 39046 applied to \textsf{SplitManifest}
+  SplitManifest = SplitVersion 1*256SplitAssetRoot
+      ;~CBOR array[2]: $[2,[r_1,\ldots,r_m]]$, $1 \leq m \leq 256$
+  SplitVersion = %d2
+  SplitAssetRoot = Bytes32
+      ;~raw SHA-256 SMST root digest; roots follow source canonical asset order
+
+  SplitMintReasonBytes = Bytes
+      ;~CBOR tag 39044 applied to \textsf{SplitMintReason}
+  SplitMintReason = SplitVersion Token 1*256CompactSMSTProof
+      ;~CBOR array[3]: $[2,\mathcal{L}_\mathsf{burn},[\bar C_1,\ldots,\bar C_q]]$
+      ;~proofs follow output canonical asset order; the token includes the certified burn
+
+  CompactSMSTProof = LeafPath 1*256CompactSMSTStep
+      ;~CBOR array[2]: $[p_1,[(p_2,s_2,w_2),\ldots,(p_n,s_n,w_n)]]$
+      ;~one to 256 steps, leaf-to-root; the final parent path is $p_n=1$
+  CompactSMSTStep = ParentPath NullableSiblingHash SiblingSum
+      ;~CBOR array[3]: $[p_i,s_i,w_i]$
+  LeafPath = 1*33OCTET
+  ParentPath = 1*33OCTET
+      ;~positive minimal unsigned big-endian SMST path segment
+  NullableSiblingHash = Bytes32 / Null
+      ;~raw SHA-256 digest or CBOR null; null iff sibling sum is zero
+  SiblingSum = *32OCTET
+      ;~minimal unsigned big-endian sum; zero is the empty byte string
+
+  SplitOutputCommitment = Bytes32
+      ;~$d_j=\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SPLIT\_OUTPUT\_V2},\mathsf{id}_\mathsf{src},\alpha,$
+      ;~$\qquad\encpred(\predi'_j),\mathsf{salt}_j,\mathsf{id}_j,\mathsf{ty}_j,\auxd'_j))$
+      ;~leaf $(\mathsf{id}_j,d_j,v_j)$ binds the allocation to the exact output mint fields

--- a/unicity-data-structs.abnf
+++ b/unicity-data-structs.abnf
@@ -213,7 +213,7 @@
 
   CompactSMSTProof = LeafPath 1*256CompactSMSTStep
       ;~CBOR array[2]: $[p_1,[(p_2,s_2,w_2),\ldots,(p_n,s_n,w_n)]]$
-      ;~one to 256 steps, leaf-to-root; the final parent path is $p_n=1$
+      ;~one to 256 steps, leaf-to-root in LSB-first SMST path order; the final parent path is $p_n=1$
   CompactSMSTStep = ParentPath NullableSiblingHash SiblingSum
       ;~CBOR array[3]: $[p_i,s_i,w_i]$
   LeafPath = 1*33OCTET

--- a/unicity-data-structs.abnf
+++ b/unicity-data-structs.abnf
@@ -82,15 +82,16 @@
 
 ; The aggregation layer uses a Radix Sparse Merkle Tree (RSMT, Appendix~\ref{app:rsmt}).
 ; Leaf-anchored: hashes commit to full 256-bit key and bifurcation depth.
-; LSB-first bit addressing.
+; Depth $d$ addresses bit $d \bmod 8$ of byte $\lfloor d/8 \rfloor$.
+; Byte order is preserved; bits are read least-significant first within each byte.
 
   StateIdentifier = Bytes32  ;~$\mathsf{sid} = H(\mathsf{CBOR}(\nu, h_{\mathsf{st}}))$ -- SMT leaf key
   LeafData = TransactionHash    ;~$h_{\mathsf{tx}}$ -- SMT leaf value
   SMTLeaf = StateIdentifier LeafData  ;~$L = (\mathsf{sid}, h_{\mathsf{tx}})$
 
   InclusionCertificate = Bitmap *SiblingHash  ;~$C^\mathsf{inc} = (\mathit{bitmap}, \langle s_1, \ldots, s_n \rangle)$
-      ;~bitmap: 32 bytes (256 bits); bit $d$ set iff sibling needed at depth $d$
-      ;~siblings: $n = \mathsf{bitcount}(\mathit{bitmap})$ hashes, leaf-to-root order
+      ;~bitmap: 32 bytes (256 bits); byte $\lfloor d/8 \rfloor$, bit $d \bmod 8$ set iff sibling needed at depth $d$
+      ;~siblings: $n = \mathsf{bitcount}(\mathit{bitmap})$ hashes, root-to-leaf order
       ;~Wire: $\mathit{bitmap}[32] \,\|\, s_1[32] \,\|\, \ldots \,\|\, s_n[32]$
 
   NonInclusionCertificate = Key Hash Bitmap *SiblingHash  ;~$C^\mathsf{exc} = (k_\ell, h_\ell, \mathit{bitmap}, \langle s_1, \ldots, s_n \rangle)$
@@ -161,7 +162,7 @@
 ; --- Fields ---
   Salt = Bytes32  ;~$\mathsf{salt}$ -- 32-byte minter-chosen salt, required to be unique among the minter's choices
   ; used to derive token identifier $\mathsf{id} = H(\mathsf{salt}, \alpha)$
-  TokenType = Bytes32  ;~$\mathsf{ty}$ -- token type classifier (32 bytes)
+  TokenType = Bytes  ;~$\mathsf{ty}$ -- token type classifier (32 bytes generated as a convention, anything supported)
   MintReason = Bytes  ;~$\mathsf{reason}$ -- mint reason (justification)
   SourceStateHash = Hash  ;~$h_\mathsf{st}$ -- current state hash (32 bytes)
   UnlockingArgument = Bytes  ;~$\mathsf{CBOR}(u)$ -- CBOR-encoded unlocking argument (see above)

--- a/unicity-data-structs.abnf
+++ b/unicity-data-structs.abnf
@@ -203,26 +203,26 @@
   SplitManifest = 1*256SplitAssetRoot
       ;~tagged CBOR array: $[r_1,\ldots,r_m]$, $1 \leq m \leq 256$
   SplitAssetRoot = Bytes32
-      ;~raw SHA-256 SMST root digest; roots follow source canonical asset order
+      ;~raw SHA-256 RSMST root digest; roots follow source canonical asset order
 
   SplitMintReasonBytes = Bytes
       ;~CBOR tag 39044 applied to \textsf{SplitMintReason}
-  SplitMintReason = Token 1*256CompactSMSTProof
+  SplitMintReason = Token 1*256SplitAllocationProof
       ;~CBOR array[2]: $[\mathcal{L}_\mathsf{burn},[\bar C_1,\ldots,\bar C_q]]$
       ;~proofs follow output canonical asset order; the token includes the certified burn
+      ;~split verification additionally requires output token type bytes to equal source token type bytes
 
-  CompactSMSTProof = LeafPath 1*256CompactSMSTStep
-      ;~CBOR array[2]: $[p_1,[(p_2,s_2,w_2),\ldots,(p_n,s_n,w_n)]]$
-      ;~one to 256 steps, leaf-to-root in LSB-first SMST path order; the final parent path is $p_n=1$
-  CompactSMSTStep = ParentPath NullableSiblingHash SiblingSum
-      ;~CBOR array[3]: $[p_i,s_i,w_i]$
-  LeafPath = 1*33OCTET
-  ParentPath = 1*33OCTET
-      ;~positive minimal unsigned big-endian SMST path segment
-  NullableSiblingHash = Bytes32 / Null
-      ;~raw SHA-256 digest or CBOR null; null iff sibling sum is zero
+  SplitAllocationProof = *256SplitAllocationStep
+      ;~CBOR array: $[(\delta_1,s_1,w_1),\ldots,(\delta_n,s_n,w_n)]$
+      ;~zero to 256 sibling entries, leaf-to-root; depths are strictly decreasing
+  SplitAllocationStep = BranchDepth SiblingHash SiblingSum
+      ;~CBOR array[3]: $[\delta_i,s_i,w_i]$
+  BranchDepth = Depth
+      ;~CBOR unsigned integer in $0,\ldots,255$
+  SiblingHash = Bytes32
+      ;~raw SHA-256 sibling subtree digest
   SiblingSum = *32OCTET
-      ;~minimal unsigned big-endian sum; zero is the empty byte string
+      ;~positive minimal unsigned big-endian sum
 
   SplitOutputCommitment = Bytes32
       ;~$d_j=\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SPLIT\_OUTPUT},\mathsf{id}_\mathsf{src},\alpha,$

--- a/unicity-data-structs.abnf
+++ b/unicity-data-structs.abnf
@@ -194,22 +194,21 @@
   Value = 1*32OCTET
       ;~$1 \leq v < 2^{256}$, minimal unsigned big-endian byte string
 
-  ; Split protocol version 2. These productions describe the decoded tagged
-  ; CBOR values. SplitManifestBytes and SplitMintReasonBytes are the complete
-  ; deterministic tagged encodings carried in transaction byte-string fields.
+  ; These productions describe the decoded tagged CBOR values.
+  ; SplitManifestBytes and SplitMintReasonBytes are the complete deterministic
+  ; tagged encodings carried in transaction byte-string fields.
 
   SplitManifestBytes = Bytes
       ;~CBOR tag 39046 applied to \textsf{SplitManifest}
-  SplitManifest = SplitVersion 1*256SplitAssetRoot
-      ;~CBOR array[2]: $[2,[r_1,\ldots,r_m]]$, $1 \leq m \leq 256$
-  SplitVersion = %d2
+  SplitManifest = 1*256SplitAssetRoot
+      ;~tagged CBOR array: $[r_1,\ldots,r_m]$, $1 \leq m \leq 256$
   SplitAssetRoot = Bytes32
       ;~raw SHA-256 SMST root digest; roots follow source canonical asset order
 
   SplitMintReasonBytes = Bytes
       ;~CBOR tag 39044 applied to \textsf{SplitMintReason}
-  SplitMintReason = SplitVersion Token 1*256CompactSMSTProof
-      ;~CBOR array[3]: $[2,\mathcal{L}_\mathsf{burn},[\bar C_1,\ldots,\bar C_q]]$
+  SplitMintReason = Token 1*256CompactSMSTProof
+      ;~CBOR array[2]: $[\mathcal{L}_\mathsf{burn},[\bar C_1,\ldots,\bar C_q]]$
       ;~proofs follow output canonical asset order; the token includes the certified burn
 
   CompactSMSTProof = LeafPath 1*256CompactSMSTStep
@@ -226,6 +225,6 @@
       ;~minimal unsigned big-endian sum; zero is the empty byte string
 
   SplitOutputCommitment = Bytes32
-      ;~$d_j=\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SPLIT\_OUTPUT\_V2},\mathsf{id}_\mathsf{src},\alpha,$
+      ;~$d_j=\mathsf{SHA\text{-}256}(\mathsf{CBOR}(\mathsf{SPLIT\_OUTPUT},\mathsf{id}_\mathsf{src},\alpha,$
       ;~$\qquad\encpred(\predi'_j),\mathsf{salt}_j,\mathsf{id}_j,\mathsf{ty}_j,\auxd'_j))$
       ;~leaf $(\mathsf{id}_j,d_j,v_j)$ binds the allocation to the exact output mint fields


### PR DESCRIPTION
  - Replaces the aggregation tree with an ordered manifest of per-asset SMST roots.
  - Removes duplicated asset IDs, amounts, roots, and aggregation paths from output proofs.
  - Binds proofs to the exact output owner, token type, payload, network, and source.
  - Defines canonical CBOR formats, strict limits, and complete verification rules.
  - Retains the full burned source token for independent verification.

  Benefit: smaller tokens and proofs, simpler verification, stronger protection against proof replay or output redirection, while preserving
  the existing trust model and per-asset value conservation.